### PR TITLE
Confirm that aleph-client on PyPI is official

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,14 @@ Description
 
 A longer description of your project goes here...
 
+Installation
+============
+
+Using pip and `PyPI <https://pypi.org/project/aleph-client/>`_:
+
+    $ pip install aleph-client
+
+
 Installation for development
 ============================
 


### PR DESCRIPTION
The `aleph-client` library on PyPI points to this repository, but there was no reference to it from this repository.
A user could not be sure that the package on PyPI was backed by the Aleph.im team.