### PR TITLE
Feature: Add more type hints

### DIFF
--- a/src/aleph_client/chains/common.py
+++ b/src/aleph_client/chains/common.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Union, Optional
+from typing import Union, Dict
 
 from coincurve import PrivateKey, PublicKey
 from ecies import decrypt
@@ -27,15 +27,15 @@ class BaseAccount:
     private_key: Union[str, bytes]
 
     @abstractmethod
-    def sign_message(self, message):
+    def sign_message(self, message: Dict) -> Dict:
         raise NotImplementedError
 
     @abstractmethod
-    def get_address(self):
+    def get_address(self) -> str:
         raise NotImplementedError
 
     @abstractmethod
-    def get_public_key(self):
+    def get_public_key(self) -> str:
         raise NotImplementedError
 
     def decrypt(self, content) -> bytes:
@@ -47,7 +47,7 @@ class BaseAccount:
 
 
 # Start of the ugly stuff
-def generate_key():
+def generate_key() -> bytes:
     privkey = PrivateKey()
     return privkey.secret
 

--- a/src/aleph_client/chains/ethereum.py
+++ b/src/aleph_client/chains/ethereum.py
@@ -1,3 +1,9 @@
+from typing import Dict
+
+from eth_account import Account
+from eth_account.account import LocalAccount
+from eth_account.messages import encode_defunct
+
 from .common import (
     BaseAccount,
     get_fallback_private_key,
@@ -5,30 +11,30 @@ from .common import (
     get_public_key,
 )
 
-from eth_account.messages import encode_defunct
-from eth_account import Account
-
 
 class ETHAccount(BaseAccount):
     CHAIN = "ETH"
     CURVE = "secp256k1"
+    _account: LocalAccount
 
     def __init__(self, private_key=None):
         self.private_key = private_key
         self._account = Account.from_key(self.private_key)
 
-    def sign_message(self, message):
+    def sign_message(self, message: Dict) -> Dict:
+        """Sign a message inplace.
+        """
         msghash = encode_defunct(text=get_verification_buffer(message).decode("utf-8"))
         sig = self._account.sign_message(msghash)
         message["signature"] = sig["signature"].hex()
         return message
 
-    def get_address(self):
+    def get_address(self) -> str:
         return self._account.address
 
-    def get_public_key(self):
+    def get_public_key(self) -> str:
         return "0x" + get_public_key(private_key=self._account.key).hex()
 
 
-def get_fallback_account():
+def get_fallback_account() -> ETHAccount:
     return ETHAccount(private_key=get_fallback_private_key())


### PR DESCRIPTION
Add type hints on chains.common, ethereum.

Use a Protocol for Account hints in order to avoid importing crypto libraries when not necessary.