### PR TITLE
Fix: A signature could not match the message's sender field

### DIFF
--- a/src/aleph_client/chains/common.py
+++ b/src/aleph_client/chains/common.py
@@ -26,6 +26,18 @@ class BaseAccount:
     CURVE: str
     private_key: Union[str, bytes]
 
+    def _setup_sender(self, message: Dict) -> Dict:
+        """Set the sender of the message as the account's public key.
+        If a sender is already specified, check that it matches the account's public key.
+        """
+        if not message.get("sender"):
+            message["sender"] = self.get_address()
+            return message
+        elif message["sender"] == self.get_address():
+            return message
+        else:
+            raise ValueError("Message sender does not match the account's public key.")
+
     @abstractmethod
     async def sign_message(self, message: Dict) -> Dict:
         raise NotImplementedError

--- a/src/aleph_client/chains/cosmos.py
+++ b/src/aleph_client/chains/cosmos.py
@@ -57,6 +57,8 @@ class CSDKAccount(BaseAccount):
         self.hrp = hrp
 
     async def sign_message(self, message):
+        message = self._setup_sender(message)
+
         verif = get_verification_string(message)
 
         privkey = ecdsa.SigningKey.from_string(self.private_key, curve=ecdsa.SECP256k1)

--- a/src/aleph_client/chains/ethereum.py
+++ b/src/aleph_client/chains/ethereum.py
@@ -24,8 +24,11 @@ class ETHAccount(BaseAccount):
     async def sign_message(self, message: Dict) -> Dict:
         """Sign a message inplace.
         """
+        message = self._setup_sender(message)
+
         msghash = encode_defunct(text=get_verification_buffer(message).decode("utf-8"))
         sig = self._account.sign_message(msghash)
+
         message["signature"] = sig["signature"].hex()
         return message
 

--- a/src/aleph_client/chains/nuls1.py
+++ b/src/aleph_client/chains/nuls1.py
@@ -345,9 +345,12 @@ class NULSAccount(BaseAccount):
         self.chain_id = chain_id
 
     async def sign_message(self, message):
+        message = self._setup_sender(message)
+
         sig = NulsSignature.sign_message(
             self.private_key, get_verification_buffer(message)
         )
+
         message["signature"] = sig.serialize().hex()
         return message
 

--- a/src/aleph_client/chains/nuls2.py
+++ b/src/aleph_client/chains/nuls2.py
@@ -41,6 +41,8 @@ class NULSAccount(BaseAccount):
     async def sign_message(self, message):
         # sig = NulsSignature.sign_message(self.private_key,
         #                                  get_verification_buffer(message))
+        message = self._setup_sender(message)
+
         sig = sign_recoverable_message(
             self.private_key, get_verification_buffer(message)
         )

--- a/src/aleph_client/chains/remote.py
+++ b/src/aleph_client/chains/remote.py
@@ -59,7 +59,9 @@ class RemoteAccount(BaseAccount):
         )
 
     def __del__(self):
-        self._session.close()
+        asyncio.get_event_loop().run_until_complete(
+            self._session.close()
+        )
 
     @property
     def private_key(self):

--- a/src/aleph_client/chains/substrate.py
+++ b/src/aleph_client/chains/substrate.py
@@ -22,6 +22,7 @@ class DOTAccount(BaseAccount):
         )
 
     async def sign_message(self, message):
+        message = self._setup_sender(message)
         verif = get_verification_buffer(message).decode("utf-8")
         sig = {"curve": self.CURVE, "data": self._account.sign(verif)}
         message["signature"] = json.dumps(sig)

--- a/tests/test_chain_ethereum.py
+++ b/tests/test_chain_ethereum.py
@@ -23,7 +23,7 @@ def test_get_fallback_account():
 async def test_ETHAccount():
     account: ETHAccount = get_fallback_account()
 
-    message = Message("ETH", "SomeSender", "SomeType", "ItemHash")
+    message = Message("ETH", account.get_address(), "SomeType", "ItemHash")
     signed = await account.sign_message(asdict(message))
     assert signed["signature"]
     assert len(signed["signature"]) == 132

--- a/tests/test_remote_account.py
+++ b/tests/test_remote_account.py
@@ -9,37 +9,36 @@ from aleph_client.chains.remote import RemoteAccount, AccountProperties
 @pytest.mark.asyncio
 async def test_remote_storage():
     host = "http://localhost:8888"
+    private_key = b'xRR\xd4P\xdb9\x93(U\xa7\xd5\x81\xba\xc7\x9fiT' \
+                  b'\xb8]\x12\x82 \xd1\x81\xc8\x94\xf0\xdav\xbb\xfb'
+    local_account = ETHAccount(private_key=private_key)
 
     with patch('aiohttp.client.ClientSession') as mock_session:
-
         mock_session.get.return_value.__aenter__.return_value.json.return_value = AccountProperties(
             chain="ETH",
             curve="secp256k1",
-            address="ADDR",
-            public_key="PUBKEY",
+            address=local_account.get_address(),
+            public_key=local_account.get_public_key(),
         ).dict()
 
         remote_account = await RemoteAccount.from_crypto_host(host=host, session=mock_session)
 
-        assert remote_account.get_address() == "ADDR"
-        assert remote_account.get_public_key() == "PUBKEY"
+        assert remote_account.get_address() == local_account.get_address()
+        assert remote_account.get_public_key() == local_account.get_public_key()
 
         # --- Test remote signing ---
 
+        expected_signature = '0xa943de6c550ddf9cd1d3e58e77e9952b9f97e1bcb2c69' \
+                             'a2f4ee56446dc8a38f02fb4a4e85c2d02efa26750456090' \
+                             '3b983b4eef8b8030cc0d89550c18c69aef081c'
         message = {
             "chain": "ETH",
-            "sender": "BOB",
+            "sender": local_account.get_address(),
             "type": "POST",
             "item_hash": "HASH",
         }
-        private_key = b'xRR\xd4P\xdb9\x93(U\xa7\xd5\x81\xba\xc7\x9fiT' \
-                      b'\xb8]\x12\x82 \xd1\x81\xc8\x94\xf0\xdav\xbb\xfb'
-        signature = '0x2e578bdeb561d2b0295494dc0d1641df67d7aa5ac5b408ee4b2' \
-                    '9124ca4db1da8702a8480af96482462fcfc5721657c9d915aa5a8' \
-                    '92189503760018519352e3161b'
-
         expected_signed_message = {
-            'signature': signature,
+            'signature': expected_signature,
         }
         expected_signed_message.update(message)
         mock_session.post.return_value.__aenter__.return_value.json.return_value\
@@ -48,8 +47,7 @@ async def test_remote_storage():
         signed_message = await remote_account.sign_message(message)
 
         assert set(signed_message.keys()) == set(message.keys()).union(['signature'])
-        assert signed_message['signature'] == signature
+        assert signed_message['signature'] == expected_signature
 
-        local_account = ETHAccount(private_key=private_key)
         local_signed_message = await local_account.sign_message(message)
         assert signed_message == local_signed_message


### PR DESCRIPTION
This enforces that the account signing the message has it's public key marked as sender of the message.