### PR TITLE
HOTFIX: add base58 to testing requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ testing =
     pytest-asyncio
     mypy
     secp256k1
+    base58
 mqtt =
     aiomqtt
     certifi


### PR DESCRIPTION
Test failed, due to missing requirements