### PR TITLE
Fix JSON serialization in aggregate creation

### DIFF
--- a/src/aleph_client/asynchronous.py
+++ b/src/aleph_client/asynchronous.py
@@ -186,7 +186,7 @@ async def create_aggregate(
 
     return await submit(
         account=account,
-        content=content_,
+        content=content_.dict(exclude_none=True),
         message_type=MessageType.aggregate,
         channel=channel,
         api_server=api_server,


### PR DESCRIPTION
Submit requires JSON serializable dict, the create_aggregate call is missing the change.