### PR TITLE
Return models instead of dictionaries

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,13 +36,16 @@ install_requires =
     eciespy
     typing_extensions
     typer
-    aleph-message>=0.1.17
+    aleph-message@git+https://github.com/aleph-im/aleph-message.git@hoh-new-type-alephmessage
     eth_account>=0.4.0
     python-magic
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 # python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+
+dependency_links =
+    https://github.com/aleph-im/aleph-message.git@hoh-new-type-alephmessage#aleph-message
 
 [options.packages.find]
 where = src

--- a/src/aleph_client/asynchronous.py
+++ b/src/aleph_client/asynchronous.py
@@ -16,6 +16,15 @@ from aleph_message.models import (
     AggregateContent,
     PostContent,
     StoreContent,
+    PostMessage,
+    Message,
+    ForgetMessage,
+    AlephMessage,
+    add_item_content_and_hash,
+    AggregateMessage,
+    StoreMessage,
+    ProgramMessage,
+    MessagesResponse,
 )
 
 from aleph_client.types import Account, StorageEnum
@@ -167,7 +176,7 @@ async def create_post(
     api_server: str = settings.API_HOST,
     inline: bool = True,
     storage_engine: StorageEnum = StorageEnum.storage,
-):
+) -> PostMessage:
     address = address or account.get_address()
 
     content = PostContent(
@@ -199,7 +208,7 @@ async def create_aggregate(
     session: Optional[ClientSession] = None,
     api_server: str = settings.API_HOST,
     inline: bool = True,
-):
+) -> AggregateMessage:
     address = address or account.get_address()
 
     content_ = AggregateContent(
@@ -232,7 +241,7 @@ async def create_store(
     channel: str = settings.DEFAULT_CHANNEL,
     session: Optional[ClientSession] = None,
     api_server: str = settings.API_HOST,
-):
+) -> StoreMessage:
     address = address or account.get_address()
     extra_fields = extra_fields or {}
 
@@ -300,7 +309,7 @@ async def create_program(
     encoding: Encoding = Encoding.zip,
     volumes: List[Dict] = None,
     subscriptions: Optional[List[Dict]] = None,
-):
+) -> ProgramMessage:
     volumes = volumes if volumes is not None else []
 
     address = address or account.get_address()
@@ -380,7 +389,7 @@ async def forget(
     address: Optional[str] = settings.ADDRESS_TO_USE,
     session: Optional[ClientSession] = None,
     api_server: str = settings.API_HOST,
-):
+) -> ForgetMessage:
     address = address or account.get_address()
 
     content = ForgetContent(
@@ -405,13 +414,13 @@ async def forget(
 async def submit(
     account: Account,
     content: Dict,
-    message_type: str,
+    message_type: MessageType,
     channel: str = settings.DEFAULT_CHANNEL,
     api_server: str = settings.API_HOST,
     storage_engine: StorageEnum = StorageEnum.storage,
     session: Optional[ClientSession] = None,
     inline: bool = True,
-):
+) -> AlephMessage:
     message: Dict[str, Any] = {
         #'item_hash': ipfs_hash,
         "chain": account.CHAIN,
@@ -428,6 +437,7 @@ async def submit(
         h = hashlib.sha256()
         h.update(message["item_content"].encode("utf-8"))
         message["item_hash"] = h.hexdigest()
+        message["item_type"] = "inline"
     else:
         if storage_engine == StorageEnum.ipfs:
             message["item_hash"] = await ipfs_push(
@@ -444,7 +454,9 @@ async def submit(
 
     # let's add the content to the object so users can access it.
     message["content"] = content
-    return message
+
+    add_item_content_and_hash(message, inplace=True)
+    return Message(**message)
 
 
 async def fetch_aggregate(
@@ -544,7 +556,7 @@ async def get_posts(
 async def get_messages(
     pagination: int = 200,
     page: int = 1,
-    message_type: Optional[str] = None,
+    message_type: Optional[MessageType] = None,
     content_types: Optional[Iterable[str]] = None,
     content_keys: Optional[Iterable[str]] = None,
     refs: Optional[Iterable[str]] = None,
@@ -557,13 +569,13 @@ async def get_messages(
     end_date: Optional[Union[datetime, float]] = None,
     session: Optional[ClientSession] = None,
     api_server: str = settings.API_HOST,
-) -> Dict[str, Any]:
+) -> MessagesResponse:
     session = session or get_fallback_session()
 
     params: Dict[str, Any] = dict(pagination=pagination, page=page)
 
     if message_type is not None:
-        params["msgType"] = message_type
+        params["msgType"] = message_type.value
     if content_types is not None:
         params["contentTypes"] = ",".join(content_types)
     if content_keys is not None:
@@ -592,11 +604,12 @@ async def get_messages(
 
     async with session.get(f"{api_server}/api/v0/messages.json", params=params) as resp:
         resp.raise_for_status()
-        return await resp.json()
+        messages_json = await resp.json()
+        return MessagesResponse(**messages_json)
 
 
 async def watch_messages(
-    message_type: Optional[str] = None,
+    message_type: Optional[MessageType] = None,
     content_types: Optional[Iterable[str]] = None,
     refs: Optional[Iterable[str]] = None,
     addresses: Optional[Iterable[str]] = None,
@@ -608,7 +621,7 @@ async def watch_messages(
     end_date: Optional[Union[datetime, float]] = None,
     session: Optional[ClientSession] = None,
     api_server: str = settings.API_HOST,
-) -> AsyncIterable[Dict[str, Any]]:
+) -> AsyncIterable[AlephMessage]:
     """
     Iterate over current and future matching messages asynchronously.
     """
@@ -618,7 +631,7 @@ async def watch_messages(
     params: Dict[str, Any] = dict()
 
     if message_type is not None:
-        params["msgType"] = message_type
+        params["msgType"] = message_type.value
     if content_types is not None:
         params["contentTypes"] = ",".join(content_types)
     if refs is not None:
@@ -653,7 +666,8 @@ async def watch_messages(
                     await ws.close()
                     break
                 else:
-                    yield json.loads(msg.data)
+                    data = json.loads(msg.data)
+                    yield Message(**data)
             elif msg.type == aiohttp.WSMsgType.ERROR:
                 break
 

--- a/src/aleph_client/synchronous.py
+++ b/src/aleph_client/synchronous.py
@@ -1,9 +1,10 @@
 import asyncio
 import queue
 import threading
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, Iterable
 
 from aiohttp import ClientSession
+from aleph_message.models import AlephMessage
 from aleph_message.models.program import ProgramContent, Encoding  # type: ignore
 
 from . import asynchronous
@@ -82,13 +83,13 @@ def create_program(
     )
 
 
-def watch_messages(*args, **kwargs):
+def watch_messages(*args, **kwargs) -> Iterable[AlephMessage]:
     """
     Iterate over current and future matching messages synchronously.
 
     Runs the `watch_messages` asynchronous generator in a thread.
     """
-    output_queue = queue.Queue()
+    output_queue: queue.Queue[AlephMessage] = queue.Queue()
     thread = threading.Thread(
         target=asynchronous._start_run_watch_messages, args=(output_queue, args, kwargs)
     )

--- a/tests/unit/test_asynchronous.py
+++ b/tests/unit/test_asynchronous.py
@@ -2,6 +2,13 @@ import os
 from unittest.mock import MagicMock, patch, AsyncMock
 
 import pytest as pytest
+from aleph_message.models import (
+    PostMessage,
+    AggregateMessage,
+    StoreMessage,
+    ProgramMessage,
+    ForgetMessage,
+)
 
 from aleph_client.conf import settings
 from aleph_client.types import StorageEnum
@@ -44,7 +51,7 @@ async def test_create_post():
 
     mock_session = new_mock_session_with_post_success()
 
-    await create_post(
+    new_post = await create_post(
         account=account,
         post_content=content,
         post_type="TEST",
@@ -54,6 +61,7 @@ async def test_create_post():
     )
 
     assert mock_session.post.called
+    assert isinstance(new_post, PostMessage)
 
 
 @pytest.mark.asyncio
@@ -78,7 +86,7 @@ async def test_create_aggregate():
         session=mock_session,
     )
 
-    await create_aggregate(
+    new_post = await create_aggregate(
         account=account,
         key="hello",
         content="world",
@@ -88,6 +96,7 @@ async def test_create_aggregate():
     )
 
     assert mock_session.post.called
+    assert isinstance(new_post, AggregateMessage)
 
 
 @pytest.mark.asyncio
@@ -132,7 +141,7 @@ async def test_create_store():
 
     with patch("aleph_client.asynchronous.storage_push_file", mock_storage_push_file):
 
-        await create_store(
+        new_post = await create_store(
             account=account,
             file_content=b"HELLO",
             channel="TEST",
@@ -142,6 +151,7 @@ async def test_create_store():
         )
 
     assert mock_session.post.called
+    assert isinstance(new_post, StoreMessage)
 
 
 @pytest.mark.asyncio
@@ -156,7 +166,7 @@ async def test_create_program():
 
     mock_session = new_mock_session_with_post_success()
 
-    await create_program(
+    new_post = await create_program(
         account=account,
         program_ref="FAKE-HASH",
         entrypoint="main:app",
@@ -167,6 +177,7 @@ async def test_create_program():
     )
 
     assert mock_session.post.called
+    assert isinstance(new_post, ProgramMessage)
 
 
 @pytest.mark.asyncio
@@ -181,7 +192,7 @@ async def test_forget():
 
     mock_session = new_mock_session_with_post_success()
 
-    await forget(
+    new_post = await forget(
         account=account,
         hashes=["FAKE-HASH"],
         reason="GDPR",
@@ -191,3 +202,4 @@ async def test_forget():
     )
 
     assert mock_session.post.called
+    assert isinstance(new_post, ForgetMessage)

--- a/tests/unit/test_asynchronous_get.py
+++ b/tests/unit/test_asynchronous_get.py
@@ -1,4 +1,5 @@
 import pytest
+from aleph_message.models import MessageType, MessagesResponse
 
 from aleph_client.asynchronous import (
     get_messages,
@@ -33,71 +34,26 @@ async def test_fetch_aggregates():
 async def test_get_posts():
     _get_fallback_session.cache_clear()
 
-    response = await get_messages(
+    response: MessagesResponse = await get_messages(
         pagination=2,
+        message_type=MessageType.post,
     )
 
-    assert response.keys() == {
-        "messages",
-        "pagination_page",
-        "pagination_total",
-        "pagination_per_page",
-        "pagination_item",
-    }
-
-    messages = response["messages"]
-    assert set(messages[0].keys()).issuperset(
-        {
-            "_id",
-            "chain",
-            "item_hash",
-            "sender",
-            "type",
-            "channel",
-            "confirmed",
-            "content",
-            "item_content",
-            "item_type",
-            "signature",
-            "size",
-            "time",
-            # 'confirmations',
-        }
-    )
+    messages = response.messages
+    assert len(messages) > 1
+    for message in messages:
+        assert message.type == MessageType.post
 
 
 @pytest.mark.asyncio
 async def test_get_messages():
     _get_fallback_session.cache_clear()
 
-    response = await get_messages(
+    response: MessagesResponse = await get_messages(
         pagination=2,
     )
 
-    assert response.keys() == {
-        "messages",
-        "pagination_page",
-        "pagination_total",
-        "pagination_per_page",
-        "pagination_item",
-    }
-
-    messages = response["messages"]
-    assert set(messages[0].keys()).issuperset(
-        {
-            "_id",
-            "chain",
-            "item_hash",
-            "sender",
-            "type",
-            "channel",
-            "confirmed",
-            "content",
-            "item_content",
-            "item_type",
-            "signature",
-            "size",
-            "time",
-            # 'confirmations',
-        }
-    )
+    messages = response.messages
+    assert len(messages) > 1
+    assert messages[0].type
+    assert messages[0].sender


### PR DESCRIPTION
These changes break the API and make it return models from Aleph-message instead of Python dictionaries.
