### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ MANIFEST
 .venv*/
 **/device.key
 
+.gitsigners


### PR DESCRIPTION
The latest version of git (2.37.1) allows for .gitsigner files, which ought to be ignored.

If it's fine with @hoh I would update the according repositories without further PRs on this matter.