### PR TITLE
Replacing go-ipfs by Kubo

### DIFF
--- a/docker/with-ipfs.dockerfile
+++ b/docker/with-ipfs.dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.9
 
 # === Install IPFS ===
-RUN apt-get install -y wget
-RUN wget https://ipfs.io/ipns/dist.ipfs.io/go-ipfs/v0.7.0/go-ipfs_v0.7.0_linux-amd64.tar.gz
-RUN tar -xvzf go-ipfs_v0.7.0_linux-amd64.tar.gz -C /opt/
-RUN ln -s /opt/go-ipfs/ipfs /usr/local/bin/
+RUN apt-get install -y wget 
+RUN wget https://ipfs.io/ipns/dist.ipfs.tech/kubo/v0.14.0/kubo_v0.14.0_linux-amd64.tar.gz
+RUN tar -xvzf kubo/v0.14.0/kubo_v0.14.0_linux-amd64.tar.gz -C /opt/
+RUN ln -s /opt/kubo/ipfs /usr/local/bin/
 
 # Volume to store IPFS data
 RUN mkdir /var/lib/ipfs


### PR DESCRIPTION
[Kubo](https://github.com/ipfs/kubo) (go-ipfs) is the earliest and most widely used implementation of IPFS.