### PR TITLE
Feature: Could not get a single message easily

### DIFF
--- a/src/aleph_client/asynchronous.py
+++ b/src/aleph_client/asynchronous.py
@@ -9,6 +9,7 @@ import threading
 import time
 from datetime import datetime
 from functools import lru_cache
+from typing import Type
 
 from aleph_message.models import (
     ForgetContent,
@@ -27,7 +28,9 @@ from aleph_message.models import (
     MessagesResponse,
 )
 
-from aleph_client.types import Account, StorageEnum
+from aleph_client.types import Account, StorageEnum, GenericMessage
+from .exceptions import MessageNotFoundError, MultipleMessagesError
+from .utils import get_message_type_value
 
 logger = logging.getLogger(__name__)
 
@@ -608,6 +611,37 @@ async def get_messages(
         resp.raise_for_status()
         messages_json = await resp.json()
         return MessagesResponse(**messages_json)
+
+
+async def get_message(
+    item_hash: str,
+    message_type: Optional[Type[GenericMessage]] = None,
+    channel: Optional[str] = None,
+    session: Optional[ClientSession] = None,
+    api_server: str = settings.API_HOST,
+) -> GenericMessage:
+    """Get a single message from its `item_hash`."""
+    messages_response = await get_messages(
+        hashes=[item_hash],
+        session=session,
+        channels=[channel] if channel else None,
+        api_server=api_server,
+    )
+    if len(messages_response.messages) < 1:
+        raise MessageNotFoundError(f"No such hash {item_hash}")
+    if len(messages_response.messages) != 1:
+        raise MultipleMessagesError(
+            f"Multiple messages found for the same item_hash `{item_hash}`"
+        )
+    message: GenericMessage = messages_response.messages[0]
+    if message_type:
+        expected_type = get_message_type_value(message_type)
+        if message.type != expected_type:
+            raise TypeError(
+                f"The message type '{message.type}' "
+                f"does not match the expected type '{expected_type}'"
+            )
+    return message
 
 
 async def watch_messages(

--- a/src/aleph_client/exceptions.py
+++ b/src/aleph_client/exceptions.py
@@ -1,0 +1,19 @@
+from abc import ABC
+
+
+class QueryError(ABC, ValueError):
+    """The result of an API query is inconsistent."""
+
+    pass
+
+
+class MessageNotFoundError(QueryError):
+    """A message was expected but could not be found."""
+
+    pass
+
+
+class MultipleMessagesError(QueryError):
+    """Multiple messages were found when a single message is expected."""
+
+    pass

--- a/src/aleph_client/synchronous.py
+++ b/src/aleph_client/synchronous.py
@@ -1,7 +1,7 @@
 import asyncio
 import queue
 import threading
-from typing import List, Optional, Dict, Iterable
+from typing import List, Optional, Dict, Iterable, Type
 
 from aiohttp import ClientSession
 from aleph_message.models import AlephMessage
@@ -9,7 +9,7 @@ from aleph_message.models.program import ProgramContent, Encoding  # type: ignor
 
 from . import asynchronous
 from .conf import settings
-from .types import Account, StorageEnum
+from .types import Account, StorageEnum, GenericMessage
 
 
 def wrap_async(func):
@@ -43,6 +43,22 @@ fetch_aggregate = wrap_async(asynchronous.fetch_aggregate)
 fetch_aggregates = wrap_async(asynchronous.fetch_aggregates)
 get_posts = wrap_async(asynchronous.get_posts)
 get_messages = wrap_async(asynchronous.get_messages)
+
+
+def get_message(
+    item_hash: str,
+    message_type: Optional[Type[GenericMessage]] = None,
+    channel: Optional[str] = None,
+    session: Optional[ClientSession] = None,
+    api_server: str = settings.API_HOST,
+) -> GenericMessage:
+    return wrap_async(asynchronous.get_message)(
+        item_hash=item_hash,
+        message_type=message_type,
+        channel=channel,
+        session=session,
+        api_server=api_server,
+    )
 
 
 def create_program(

--- a/src/aleph_client/types.py
+++ b/src/aleph_client/types.py
@@ -1,8 +1,10 @@
 from abc import abstractmethod
 from enum import Enum
-from typing import Protocol, Dict
+from typing import Protocol, Dict, TypeVar
 
 __all__ = ("StorageEnum", "Account", "AccountFromPrivateKey")
+
+from aleph_message.models import AlephMessage
 
 
 class StorageEnum(str, Enum):
@@ -33,3 +35,6 @@ class AccountFromPrivateKey(Account, Protocol):
 
     def __init__(self, private_key: bytes):
         ...
+
+
+GenericMessage = TypeVar("GenericMessage", bound=AlephMessage)

--- a/src/aleph_client/utils.py
+++ b/src/aleph_client/utils.py
@@ -2,12 +2,14 @@ import logging
 import os
 from pathlib import Path
 from shutil import make_archive
-from typing import Tuple
+from typing import Tuple, Type
 from zipfile import ZipFile, BadZipFile
 
+from aleph_message.models import MessageType
 from aleph_message.models.program import Encoding
 
 from aleph_client.conf import settings
+from aleph_client.types import GenericMessage
 
 logger = logging.getLogger(__name__)
 
@@ -52,3 +54,9 @@ def create_archive(path: Path) -> Tuple[Path, Encoding]:
             return path, Encoding.zip
     else:
         raise FileNotFoundError("No file or directory to create the archive from")
+
+
+def get_message_type_value(message_type: Type[GenericMessage]) -> MessageType:
+    """Returns the value of the 'type' field of a message type class."""
+    type_literal = message_type.__annotations__["type"]
+    return type_literal.__args__[0]  # Get the value from a Literal

--- a/tests/integration/itest_posts.py
+++ b/tests/integration/itest_posts.py
@@ -1,5 +1,6 @@
 import pytest
 from aleph_message import Message
+from aleph_message.models import PostMessage, MessagesResponse
 
 from aleph_client.asynchronous import (
     create_post,
@@ -16,7 +17,7 @@ async def create_message_on_target(
     Create a POST message on the target node, then fetch it from the reference node.
     """
 
-    created_message_dict = await create_post(
+    created_message_dict: PostMessage = await create_post(
         account=fixture_account,
         post_content=None,
         post_type="POST",
@@ -25,12 +26,15 @@ async def create_message_on_target(
         api_server=emitter_node,
     )
 
+    def response_contains_messages(response: MessagesResponse) -> bool:
+        return len(response.messages) > 0
+
     # create_message = Message(**created_message_dict)
     response_dict = await try_until(
         get_messages,
-        lambda response: len(response["messages"]) > 0,
+        response_contains_messages,
         timeout=5,
-        hashes=[created_message_dict["item_hash"]],
+        hashes=[created_message_dict.item_hash],
         api_server=receiver_node,
     )
 

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from typing import Any, Awaitable, Callable, TypeVar
+from typing import Awaitable, Callable, TypeVar
 
 T = TypeVar("T")
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,18 @@
+from aleph_message.models import (
+    MessageType,
+    PostMessage,
+    AggregateMessage,
+    StoreMessage,
+    ProgramMessage,
+    ForgetMessage,
+)
+
+from aleph_client.utils import get_message_type_value
+
+
+def test_get_message_type_value():
+    assert get_message_type_value(PostMessage) == MessageType.post
+    assert get_message_type_value(AggregateMessage) == MessageType.aggregate
+    assert get_message_type_value(StoreMessage) == MessageType.store
+    assert get_message_type_value(ProgramMessage) == MessageType.program
+    assert get_message_type_value(ForgetMessage) == MessageType.forget


### PR DESCRIPTION
A user could not easily get a single message from the API server, with a clear error message when failing.

Solution: Add function `get_message` singular.