### PR TITLE
Fix: Received item_hash is the same as in Aleph Explorer

### DIFF
--- a/src/aleph_client/asynchronous.py
+++ b/src/aleph_client/asynchronous.py
@@ -20,7 +20,6 @@ from aleph_message.models import (
     Message,
     ForgetMessage,
     AlephMessage,
-    add_item_content_and_hash,
     AggregateMessage,
     StoreMessage,
     ProgramMessage,
@@ -457,7 +456,6 @@ async def submit(
     # let's add the content to the object so users can access it.
     message["content"] = content
 
-    add_item_content_and_hash(message, inplace=True)
     return Message(**message)
 
 


### PR DESCRIPTION
Problem: Python client returns Messages with different item_hash from what is seen on Aleph Explorer:

Solution: Remove double calculation of item_hash introduced in PR #74