### PR TITLE
Fix: Any invalid message in a response crashed the entire response

### DIFF
--- a/src/aleph_client/models.py
+++ b/src/aleph_client/models.py
@@ -1,0 +1,14 @@
+from typing import List
+
+from aleph_message.models import AlephMessage
+from pydantic import BaseModel
+
+
+class MessagesResponse(BaseModel):
+    """Response from an Aleph node API on the path /api/v0/messages.json"""
+
+    messages: List[AlephMessage]
+    pagination_page: int
+    pagination_total: int
+    pagination_per_page: int
+    pagination_item: str


### PR DESCRIPTION
The code serving the API may return messages that are not valid according the latest version of the schemas. Ignore them with an optional log instead of failing the parsing of the entire response.

This is an alternative to https://github.com/aleph-im/aleph-message/pull/27 . Putting this logic in the client library allows users to add more options on how invalid messages should be handled.