### PR TITLE
Fix: PyPI does not accept git dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ testing =
     base58
     fastapi
     requests
-    aleph-pytezos@git+https://github.com/aleph-im/aleph-pytezos.git@e584ede63c4302c6c22ac1777fda6676655d664a
+    aleph-pytezos==0.1.0
 mqtt =
     aiomqtt
     certifi
@@ -82,7 +82,7 @@ solana =
     base58
 tezos =
     pynacl
-    aleph-pytezos@git+https://github.com/aleph-im/aleph-pytezos.git@e584ede63c4302c6c22ac1777fda6676655d664a
+    aleph-pytezos==0.1.0
 docs =
     sphinxcontrib-plantuml
 


### PR DESCRIPTION
This prevented us from uploading new versions on PyPI.