### PR TITLE
Chore: fix substrate-interface version to 1.3.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ nuls2 =
 ethereum =
     eth_account>=0.4.0
 polkadot =
-    substrate-interface
+    substrate-interface==1.3.4
 cosmos =
     cosmospy
 solana =


### PR DESCRIPTION
Chore: aleph-client and pyaleph are not synchronized on substrate-interface version.
Solution: Update substrate-interface from LTS to 1.3.4.

related to: https://github.com/aleph-im/pyaleph/pull/358 on pyaleph.