### PR TITLE
Fix: Command whoami printed public key, not address

### DIFF
--- a/src/aleph_client/__main__.py
+++ b/src/aleph_client/__main__.py
@@ -45,7 +45,7 @@ def whoami(
     """
 
     account: AccountFromPrivateKey = _load_account(private_key, private_key_file)
-    typer.echo(account.get_public_key())
+    typer.echo(account.get_address())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The command `aleph whoami` did not print the address used by the user.

```
$ aleph whoami
0x75aB2CDEd7981eD547BdCd1a9df2C5ccC8203D0F

$ git checkout master
Switched to branch 'master'
$ aleph whoami
0x031df8a6e3c2c1ab83b0ca937e12f02437108c239a2c60dbe62499a4429b2efb4e
```

This can be traced to a different behaviour, here for ethereum:
```python
    def get_address(self) -> str:
        return self._account.address

    def get_public_key(self) -> str:
        return "0x" + get_public_key(private_key=self._account.key).hex()
```