### PR TITLE
Feat: Get raw storage file (issue #60)

### DIFF
--- a/src/aleph_client/asynchronous.py
+++ b/src/aleph_client/asynchronous.py
@@ -564,7 +564,6 @@ async def get_posts(
 
 async def get_store_file(
         file_hash: str,
-        storage_engine: Optional[StorageEnum] = None,
         session: Optional[ClientSession] = None,
         api_server: Optional[str] = None
 ) -> bytes:
@@ -572,25 +571,15 @@ async def get_store_file(
     Get a file from the storage engine as raw bytes.
 
     :param file_hash: The hash of the file to retrieve.
-    :param storage_engine: The storage engine to use. (DEFAULT: "storage")
     :param session: The aiohttp session to use. (DEFAULT: get_fallback_session())
     :param api_server: The API server to use. (DEFAULT: "https://api2.aleph.im")
     """
-    storage_engine = storage_engine or StorageEnum.storage
     session = session or get_fallback_session()
     api_server = api_server or settings.API_HOST
 
-    if storage_engine == StorageEnum.storage:
-        async with session.get(f"{api_server}/api/v0/storage/raw/{file_hash}") as response:
-            response.raise_for_status()
-            return await response.read()
-    elif storage_engine == StorageEnum.ipfs:
-        async with session.get(f"{api_server}/api/v0/ipfs/files/read/{file_hash}") as response:
-            response.raise_for_status()
-            return await response.read()
-    else:
-        raise ValueError(f"Invalid storage engine: {storage_engine}")
-
+    async with session.get(f"{api_server}/api/v0/storage/raw/{file_hash}") as response:
+        response.raise_for_status()
+        return await response.read()
 
 async def get_messages(
         pagination: int = 200,

--- a/src/aleph_client/asynchronous.py
+++ b/src/aleph_client/asynchronous.py
@@ -562,13 +562,15 @@ async def get_posts(
         return await resp.json()
 
 
-async def get_store_file(
+async def download_file(
         file_hash: str,
         session: Optional[ClientSession] = None,
         api_server: Optional[str] = None
 ) -> bytes:
     """
     Get a file from the storage engine as raw bytes.
+
+    Warning: Downloading large files can be slow and memory intensive.
 
     :param file_hash: The hash of the file to retrieve.
     :param session: The aiohttp session to use. (DEFAULT: get_fallback_session())
@@ -580,6 +582,7 @@ async def get_store_file(
     async with session.get(f"{api_server}/api/v0/storage/raw/{file_hash}") as response:
         response.raise_for_status()
         return await response.read()
+
 
 async def get_messages(
         pagination: int = 200,


### PR DESCRIPTION
Problem: There's no function to download storage data by its item hash (see issue #60)

Solution: Add get_store_file()