### PR TITLE
Feature: refactor the broadcast function

### DIFF
--- a/examples/httpgateway.py
+++ b/examples/httpgateway.py
@@ -38,12 +38,12 @@ async def source_post(request):
         if secret != app['secret']:
             return web.json_response({'status': 'error',
                                       'message': 'unauthorized secret'})
-    value = await create_post(app['account'], data,
+    message, _status = await create_post(app['account'], data,
                               'event', channel=app['channel'],
                               api_server='https://api2.aleph.im')
 
     return web.json_response({'status': 'success',
-                              'item_hash': value['item_hash']})
+                              'item_hash': message.item_hash})
     
 
 @click.command()

--- a/examples/metrics.py
+++ b/examples/metrics.py
@@ -70,8 +70,8 @@ def main():
     account = get_fallback_account()
     while True:
         metrics = collect_metrics()
-        ret = send_metrics(account, metrics)
-        print("sent", ret['item_hash'])
+        message, status = send_metrics(account, metrics)
+        print("sent", message.item_hash)
         time.sleep(10)
 
 

--- a/examples/store.py
+++ b/examples/store.py
@@ -6,15 +6,17 @@ import click
 from aleph_client.chains.ethereum import ETHAccount
 from aleph_client.chains.common import get_fallback_private_key
 from aleph_client.asynchronous import create_store
+from aleph_client.types import MessageStatus
+from aleph_message.models import AlephMessage, StoreMessage
 
 DEFAULT_SERVER = "https://api2.aleph.im"
 
-async def print_output_hash(message):
+async def print_output_hash(message: StoreMessage, status: MessageStatus):
     print("Successfully created STORE message")
-    print(f"File hash ({message['content']['item_type']}): {message['content']['item_hash']}")
-    print("Sender: ", message['sender'])
-    print(f"Message hash: {message['item_hash']}")
-    print(f"Explorer URL: https://explorer.aleph.im/address/{message['chain']}/{message['sender']}/message/{message['item_hash']}")
+    print(f"File hash ({message.content.item_type}): {message.content.item_hash}")
+    print("Sender: ", message.sender)
+    print(f"Message hash: {message.item_hash}")
+    print(f"Explorer URL: https://explorer.aleph.im/address/{message.chain.value}/{message.sender}/message/{message.item_hash}")
 
 async def do_upload(account, engine, channel, filename=None, file_hash=None):
     async with aiohttp.ClientSession() as session:
@@ -34,10 +36,10 @@ async def do_upload(account, engine, channel, filename=None, file_hash=None):
                 raise
 
         elif file_hash:
-            result = await create_store(account, file_hash=file_hash,
+            message, status = await create_store(account, file_hash=file_hash,
                                         channel=channel, storage_engine=engine.lower(), session=session)
             
-        await print_output_hash(result)
+        await print_output_hash(message, status)
 
 @click.command()
 @click.argument('filename', )

--- a/src/aleph_client/commands/aggregate.py
+++ b/src/aleph_client/commands/aggregate.py
@@ -42,5 +42,5 @@ def forget(
         message_type=MessageType.aggregate.value,
         content_keys=[key],
     )
-    hash_list = [message["item_hash"] for message in message_response["messages"]]
+    hash_list = [message["item_hash"] for message in message_response.messages]
     forget_messages(account, hash_list, reason, channel)

--- a/src/aleph_client/commands/message.py
+++ b/src/aleph_client/commands/message.py
@@ -131,13 +131,13 @@ def amend(
     new_content = content_type(**new_content_dict)
     new_content.ref = existing_message.item_hash
     typer.echo(new_content)
-    result = synchronous.submit(
+    message, _status = synchronous.submit(
         account=account,
         content=new_content.dict(),
         message_type=existing_message.type,
         channel=existing_message.channel,
     )
-    typer.echo(f"{result.json(indent=4)}")
+    typer.echo(f"{message.json(indent=4)}")
 
 
 def forget_messages(

--- a/src/aleph_client/commands/program.py
+++ b/src/aleph_client/commands/program.py
@@ -173,7 +173,7 @@ def upload(
             program_ref = user_code.item_hash
 
         # Register the program
-        result: ProgramMessage = synchronous.create_program(
+        message, status = synchronous.create_program(
             account=account,
             program_ref=program_ref,
             entrypoint=entrypoint,
@@ -190,9 +190,9 @@ def upload(
         )
         logger.debug("Upload finished")
         if print_messages or print_program_message:
-            typer.echo(f"{result.json(indent=4)}")
+            typer.echo(f"{message.json(indent=4)}")
 
-        hash: str = result.item_hash
+        hash: str = message.item_hash
         hash_base32 = b32encode(b16decode(hash.upper())).strip(b"=").lower().decode()
 
         typer.echo(
@@ -201,7 +201,7 @@ def upload(
             f"  {settings.VM_URL_PATH.format(hash=hash)}\n"
             f"  {settings.VM_URL_HOST.format(hash_base32=hash_base32)}\n"
             "Visualise on:\n  https://explorer.aleph.im/address/"
-            f"{result.chain}/{result.sender}/message/PROGRAM/{hash}\n"
+            f"{message.chain}/{message.sender}/message/PROGRAM/{hash}\n"
         )
 
     finally:
@@ -256,7 +256,7 @@ def update(
             # TODO: Read in lazy mode instead of copying everything in memory
             file_content = fd.read()
             logger.debug("Uploading file")
-            result = synchronous.create_store(
+            message, status = synchronous.create_store(
                 account=account,
                 file_content=file_content,
                 storage_engine=code_message.content.item_type,
@@ -266,7 +266,7 @@ def update(
             )
             logger.debug("Upload finished")
             if print_message:
-                typer.echo(f"{result.json(indent=4)}")
+                typer.echo(f"{message.json(indent=4)}")
     finally:
         # Prevent aiohttp unclosed connector warning
         asyncio.run(get_fallback_session().close())
@@ -292,10 +292,10 @@ def unpersist(
     content.on.persistent = False
     content.replaces = message.item_hash
 
-    result = synchronous.submit(
+    message, _status = synchronous.submit(
         account=account,
         content=content.dict(exclude_none=True),
         message_type=message.type,
         channel=message.channel,
     )
-    typer.echo(f"{result.json(indent=4)}")
+    typer.echo(f"{message.json(indent=4)}")

--- a/src/aleph_client/conf.py
+++ b/src/aleph_client/conf.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
 
     PRIVATE_KEY_STRING: Optional[str] = None
     API_HOST: str = "https://api2.aleph.im"
+    MAX_INLINE_SIZE: int = 50000
     API_UNIX_SOCKET: Optional[str] = None
     REMOTE_CRYPTO_HOST: Optional[str] = None
     REMOTE_CRYPTO_UNIX_SOCKET: Optional[str] = None

--- a/src/aleph_client/exceptions.py
+++ b/src/aleph_client/exceptions.py
@@ -17,3 +17,20 @@ class MultipleMessagesError(QueryError):
     """Multiple messages were found when a single message is expected."""
 
     pass
+
+
+class BroadcastError(Exception):
+    """
+    Data could not be broadcast to the Aleph network.
+    """
+
+    pass
+
+
+class InvalidMessageError(BroadcastError):
+    """
+    The message could not be broadcast because it does not follow the Aleph
+    message specification.
+    """
+
+    pass

--- a/src/aleph_client/synchronous.py
+++ b/src/aleph_client/synchronous.py
@@ -1,7 +1,7 @@
 import asyncio
 import queue
 import threading
-from typing import List, Optional, Dict, Iterable, Type
+from typing import Any, Callable, List, Optional, Dict, Iterable, Type, Protocol, TypeVar, Awaitable
 
 from aiohttp import ClientSession
 from aleph_message.models import AlephMessage
@@ -12,7 +12,10 @@ from .conf import settings
 from .types import Account, StorageEnum, GenericMessage
 
 
-def wrap_async(func):
+T = TypeVar("T")
+
+
+def wrap_async(func: Callable[..., Awaitable[T]]) -> Callable[..., T]:
     """Wrap an asynchronous function into a synchronous one,
     for easy use in synchronous code.
     """
@@ -35,7 +38,6 @@ ipfs_push = wrap_async(asynchronous.ipfs_push)
 storage_push = wrap_async(asynchronous.storage_push)
 ipfs_push_file = wrap_async(asynchronous.ipfs_push_file)
 storage_push_file = wrap_async(asynchronous.storage_push_file)
-broadcast = wrap_async(asynchronous.broadcast)
 create_aggregate = wrap_async(asynchronous.create_aggregate)
 create_store = wrap_async(asynchronous.create_store)
 submit = wrap_async(asynchronous.submit)

--- a/src/aleph_client/types.py
+++ b/src/aleph_client/types.py
@@ -12,6 +12,14 @@ class StorageEnum(str, Enum):
     storage = "storage"
 
 
+# TODO: this class is duplicated in pyaleph. Move it to aleph-message.
+class MessageStatus(str, Enum):
+    PENDING = "pending"
+    PROCESSED = "processed"
+    REJECTED = "rejected"
+    FORGOTTEN = "forgotten"
+
+
 # Use a protocol to avoid importing crypto libraries
 class Account(Protocol):
     CHAIN: str

--- a/tests/integration/itest_aggregates.py
+++ b/tests/integration/itest_aggregates.py
@@ -20,7 +20,7 @@ async def create_aggregate_on_target(
     receiver_node: str,
     channel="INTEGRATION_TESTS",
 ):
-    aggregate_dict = await create_aggregate(
+    aggregate_message, message_status = await create_aggregate(
         account=account,
         key=key,
         content=content,
@@ -28,16 +28,16 @@ async def create_aggregate_on_target(
         api_server=emitter_node,
     )
 
-    assert aggregate_dict["sender"] == account.get_address()
-    assert aggregate_dict["channel"] == channel
+    assert aggregate_message.sender == account.get_address()
+    assert aggregate_message.channel == channel
     # Note: lots of duplicates in the response
-    item_content = json.loads(aggregate_dict["item_content"])
+    item_content = json.loads(aggregate_message.item_content)
     assert item_content["key"] == key
     assert item_content["content"] == content
     assert item_content["address"] == account.get_address()
-    assert aggregate_dict["content"]["key"] == key
-    assert aggregate_dict["content"]["address"] == account.get_address()
-    assert aggregate_dict["content"]["content"] == content
+    assert aggregate_message.content.key == key
+    assert aggregate_message.content.address == account.get_address()
+    assert aggregate_message.content.content == content
 
     aggregate_from_receiver = await try_until(
         fetch_aggregate,

--- a/tests/integration/itest_forget.py
+++ b/tests/integration/itest_forget.py
@@ -22,7 +22,7 @@ async def create_and_forget_post(
             api_server=receiver_node,
         )
 
-    create_post_response = await create_post(
+    post_message, message_status = await create_post(
         account=account,
         post_content="A considerate and politically correct post.",
         post_type="POST",
@@ -34,14 +34,14 @@ async def create_and_forget_post(
     # Wait for the message to appear on the receiver. We don't check the values,
     # they're checked in other integration tests.
     get_post_response = await wait_matching_posts(
-        create_post_response["item_hash"],
+        post_message.item_hash,
         lambda response: len(response["posts"]) > 0,
     )
     print(get_post_response)
 
-    post_hash = create_post_response["item_hash"]
+    post_hash = post_message.item_hash
     reason = "This well thought-out content offends me!"
-    forget_response = await forget(
+    forget_message, forget_status = await forget(
         account,
         hashes=[post_hash],
         reason=reason,
@@ -49,22 +49,22 @@ async def create_and_forget_post(
         api_server=emitter_node,
     )
 
-    assert forget_response["sender"] == account.get_address()
-    assert forget_response["content"]["reason"] == reason
-    assert forget_response["content"]["hashes"] == [post_hash]
+    assert forget_message.sender == account.get_address()
+    assert forget_message.content.reason == reason
+    assert forget_message.content.hashes == [post_hash]
 
-    print(forget_response)
+    print(forget_message)
 
     # Wait until the message is forgotten
     forgotten_posts = await wait_matching_posts(
-        create_post_response["item_hash"],
+        post_hash,
         lambda response: "forgotten_by" in response["posts"][0],
         timeout=15,
     )
 
     assert len(forgotten_posts["posts"]) == 1
     forgotten_post = forgotten_posts["posts"][0]
-    assert forgotten_post["forgotten_by"] == [forget_response["item_hash"]]
+    assert forgotten_post["forgotten_by"] == [forget_message.item_hash]
     assert forgotten_post["item_content"] is None
     print(forgotten_post)
 
@@ -102,7 +102,7 @@ async def test_forget_a_forget_message(fixture_account):
     post = get_post_response["posts"][0]
 
     forget_message_hash = post["forgotten_by"][0]
-    forget_response = await forget(
+    forget_message, forget_status = await forget(
         fixture_account,
         hashes=[forget_message_hash],
         reason="I want to remember this post. Maybe I can forget I forgot it?",
@@ -110,7 +110,7 @@ async def test_forget_a_forget_message(fixture_account):
         api_server=TARGET_NODE,
     )
 
-    print(forget_response)
+    print(forget_message)
 
     get_forget_message_response = await get_messages(
         hashes=[forget_message_hash], channels=[TEST_CHANNEL], api_server=TARGET_NODE

--- a/tests/integration/itest_posts.py
+++ b/tests/integration/itest_posts.py
@@ -17,7 +17,7 @@ async def create_message_on_target(
     Create a POST message on the target node, then fetch it from the reference node.
     """
 
-    created_message_dict: PostMessage = await create_post(
+    post_message, message_status = await create_post(
         account=fixture_account,
         post_content=None,
         post_type="POST",
@@ -34,12 +34,12 @@ async def create_message_on_target(
         get_messages,
         response_contains_messages,
         timeout=5,
-        hashes=[created_message_dict.item_hash],
+        hashes=[post_message.item_hash],
         api_server=receiver_node,
     )
 
     message_from_target = Message(**response_dict["messages"][0])
-    assert created_message_dict["item_hash"] == message_from_target.item_hash
+    assert post_message.item_hash == message_from_target.item_hash
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Problem: the broadcast function does not give enough information on the status of the broadcast operation. Some logs are printed but there is no way for the user to determine the status of the message processing + broadcast programmatically.

Solution: refactor the broadcast function so that:
1. it now returns the status of the message, if successful (pending or processed)
2. it raises a `BroadcastError` exception if the broadcast operation failed for some reason.

Renamed `broadcast` to `_broadcast` as it is now considered a private function.