### PR TITLE
Internal: user session class

### DIFF
--- a/examples/httpgateway.py
+++ b/examples/httpgateway.py
@@ -19,6 +19,8 @@ from aleph_client.chains.common import get_fallback_private_key
 
 from aiohttp import web
 
+from aleph_client.user_session import UserSession
+
 app = web.Application()
 routes = web.RouteTableDef()
 
@@ -42,13 +44,13 @@ async def source_post(request):
             return web.json_response(
                 {"status": "error", "message": "unauthorized secret"}
             )
-    message, _status = await create_post(
-        app["account"],
-        data,
-        "event",
-        channel=app["channel"],
-        api_server="https://api2.aleph.im",
-    )
+    async with UserSession(account=app["account"], api_server="https://api2.aleph.im") as session:
+        message, _status = await create_post(
+            session=session,
+            post_content=data,
+            post_type="event",
+            channel=app["channel"],
+        )
 
     return web.json_response({"status": "success", "item_hash": message.item_hash})
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ testing =
     pytest
     pytest-cov
     pytest-asyncio
+    pytest-mock
     mypy
     secp256k1
     pynacl
@@ -69,6 +70,7 @@ testing =
     httpx
     requests
     aleph-pytezos==0.1.0
+    types-certifi
     types-setuptools
 mqtt =
     aiomqtt

--- a/src/aleph_client/commands/files.py
+++ b/src/aleph_client/commands/files.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from pathlib import Path
 from typing import Optional
@@ -8,7 +7,6 @@ from aleph_message.models import StoreMessage
 
 from aleph_client import synchronous
 from aleph_client.account import _load_account
-from aleph_client.asynchronous import get_fallback_session
 from aleph_client.commands import help_strings
 from aleph_client.commands.utils import setup_logging
 from aleph_client.conf import settings
@@ -37,20 +35,15 @@ def pin(
 
     account: AccountFromPrivateKey = _load_account(private_key, private_key_file)
 
-    try:
-        result: StoreMessage = synchronous.create_store(
-            account=account,
-            file_hash=hash,
-            storage_engine=StorageEnum.ipfs,
-            channel=channel,
-            ref=ref,
-        )
-        logger.debug("Upload finished")
-        typer.echo(f"{result.json(indent=4)}")
-    finally:
-        # Prevent aiohttp unclosed connector warning
-        asyncio.run(get_fallback_session().close())
-
+    result: StoreMessage = synchronous.create_store(
+        account=account,
+        file_hash=hash,
+        storage_engine=StorageEnum.ipfs,
+        channel=channel,
+        ref=ref,
+    )
+    logger.debug("Upload finished")
+    typer.echo(f"{result.json(indent=4)}")
 
 @app.command()
 def upload(
@@ -71,31 +64,27 @@ def upload(
 
     account: AccountFromPrivateKey = _load_account(private_key, private_key_file)
 
-    try:
-        if not path.is_file():
-            typer.echo(f"Error: File not found: '{path}'")
-            raise typer.Exit(code=1)
+    if not path.is_file():
+        typer.echo(f"Error: File not found: '{path}'")
+        raise typer.Exit(code=1)
 
-        with open(path, "rb") as fd:
-            logger.debug("Reading file")
-            # TODO: Read in lazy mode instead of copying everything in memory
-            file_content = fd.read()
-            storage_engine = (
-                StorageEnum.ipfs
-                if len(file_content) > 4 * 1024 * 1024
-                else StorageEnum.storage
-            )
-            logger.debug("Uploading file")
-            result: StoreMessage = synchronous.create_store(
-                account=account,
-                file_content=file_content,
-                storage_engine=storage_engine,
-                channel=channel,
-                guess_mime_type=True,
-                ref=ref,
-            )
-            logger.debug("Upload finished")
-            typer.echo(f"{result.json(indent=4)}")
-    finally:
-        # Prevent aiohttp unclosed connector warning
-        asyncio.run(get_fallback_session().close())
+    with open(path, "rb") as fd:
+        logger.debug("Reading file")
+        # TODO: Read in lazy mode instead of copying everything in memory
+        file_content = fd.read()
+        storage_engine = (
+            StorageEnum.ipfs
+            if len(file_content) > 4 * 1024 * 1024
+            else StorageEnum.storage
+        )
+        logger.debug("Uploading file")
+        result: StoreMessage = synchronous.create_store(
+            account=account,
+            file_content=file_content,
+            storage_engine=storage_engine,
+            channel=channel,
+            guess_mime_type=True,
+            ref=ref,
+        )
+        logger.debug("Upload finished")
+        typer.echo(f"{result.json(indent=4)}")

--- a/src/aleph_client/commands/message.py
+++ b/src/aleph_client/commands/message.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import os.path
 import subprocess
@@ -15,7 +14,6 @@ from aleph_message.models import (
 
 from aleph_client import synchronous
 from aleph_client.account import _load_account
-from aleph_client.asynchronous import get_fallback_session
 from aleph_client.commands import help_strings
 from aleph_client.commands.utils import (
     setup_logging,
@@ -78,20 +76,16 @@ def post(
             typer.echo("Not valid JSON")
             raise typer.Exit(code=2)
 
-    try:
-        result: PostMessage = synchronous.create_post(
-            account=account,
-            post_content=content,
-            post_type=type,
-            ref=ref,
-            channel=channel,
-            inline=True,
-            storage_engine=storage_engine,
-        )
-        typer.echo(result.json(indent=4))
-    finally:
-        # Prevent aiohttp unclosed connector warning
-        asyncio.run(get_fallback_session().close())
+    result: PostMessage = synchronous.create_post(
+        account=account,
+        post_content=content,
+        post_type=type,
+        ref=ref,
+        channel=channel,
+        inline=True,
+        storage_engine=storage_engine,
+    )
+    typer.echo(result.json(indent=4))
 
 
 @app.command()
@@ -146,17 +140,13 @@ def forget_messages(
         reason: Optional[str],
         channel: str,
 ):
-    try:
-        result: ForgetMessage = synchronous.forget(
-            account=account,
-            hashes=hashes,
-            reason=reason,
-            channel=channel,
-        )
-        typer.echo(f"{result.json(indent=4)}")
-    finally:
-        # Prevent aiohttp unclosed connector warning
-        asyncio.run(get_fallback_session().close())
+    result: ForgetMessage = synchronous.forget(
+        account=account,
+        hashes=hashes,
+        reason=reason,
+        channel=channel,
+    )
+    typer.echo(f"{result.json(indent=4)}")
 
 
 @app.command()

--- a/src/aleph_client/commands/program.py
+++ b/src/aleph_client/commands/program.py
@@ -16,7 +16,6 @@ from aleph_message.models import (
 
 from aleph_client import synchronous
 from aleph_client.account import _load_account
-from aleph_client.asynchronous import get_fallback_session
 from aleph_client.commands import help_strings
 from aleph_client.commands.utils import (
     setup_logging,
@@ -36,62 +35,58 @@ app = typer.Typer()
 
 @app.command()
 def upload(
-        path: Path = typer.Argument(..., help="Path to your source code"),
-        entrypoint: str = typer.Argument(..., help="Your program entrypoint"),
-        channel: str = typer.Option(settings.DEFAULT_CHANNEL, help=help_strings.CHANNEL),
-        memory: int = typer.Option(
-            settings.DEFAULT_VM_MEMORY, help="Maximum memory allocation on vm in MiB"
-        ),
-        vcpus: int = typer.Option(
-            settings.DEFAULT_VM_VCPUS, help="Number of virtual cpus to allocate."
-        ),
-        timeout_seconds: float = typer.Option(
-            settings.DEFAULT_VM_TIMEOUT,
-            help="If vm is not called after [timeout_seconds] it will shutdown",
-        ),
-        private_key: Optional[str] = typer.Option(
-            settings.PRIVATE_KEY_STRING, help=help_strings.PRIVATE_KEY
-        ),
-        private_key_file: Optional[Path] = typer.Option(
-            settings.PRIVATE_KEY_FILE, help=help_strings.PRIVATE_KEY_FILE
-        ),
-        print_messages: bool = typer.Option(False),
-        print_code_message: bool = typer.Option(False),
-        print_program_message: bool = typer.Option(False),
-        runtime: str = typer.Option(
-            None,
-            help="Hash of the runtime to use for your program. Defaults to aleph debian with Python3.8 and node. You can also create your own runtime and pin it",
-        ),
-        beta: bool = typer.Option(False),
-
-        debug: bool = False,
-        persistent: bool = False,
-        persistent_volume: Optional[List[str]] = typer.Option(
-            None,
-            help='''Takes 3 parameters                                                                                                                             
+    path: Path = typer.Argument(..., help="Path to your source code"),
+    entrypoint: str = typer.Argument(..., help="Your program entrypoint"),
+    channel: str = typer.Option(settings.DEFAULT_CHANNEL, help=help_strings.CHANNEL),
+    memory: int = typer.Option(
+        settings.DEFAULT_VM_MEMORY, help="Maximum memory allocation on vm in MiB"
+    ),
+    vcpus: int = typer.Option(
+        settings.DEFAULT_VM_VCPUS, help="Number of virtual cpus to allocate."
+    ),
+    timeout_seconds: float = typer.Option(
+        settings.DEFAULT_VM_TIMEOUT,
+        help="If vm is not called after [timeout_seconds] it will shutdown",
+    ),
+    private_key: Optional[str] = typer.Option(
+        settings.PRIVATE_KEY_STRING, help=help_strings.PRIVATE_KEY
+    ),
+    private_key_file: Optional[Path] = typer.Option(
+        settings.PRIVATE_KEY_FILE, help=help_strings.PRIVATE_KEY_FILE
+    ),
+    print_messages: bool = typer.Option(False),
+    print_code_message: bool = typer.Option(False),
+    print_program_message: bool = typer.Option(False),
+    runtime: str = typer.Option(
+        None,
+        help="Hash of the runtime to use for your program. Defaults to aleph debian with Python3.8 and node. You can also create your own runtime and pin it",
+    ),
+    beta: bool = typer.Option(False),
+    debug: bool = False,
+    persistent: bool = False,
+    persistent_volume: Optional[List[str]] = typer.Option(
+        None,
+        help="""Takes 3 parameters                                                                                                                             
         A persistent volume is allocated on the host machine at any time                                             
         eg: Use , to seperate the parameters and no spaces                                                                   
         --persistent_volume persistence=host,name=my-volume,size=100 ./my-program main:app
-        '''),
-
-        ephemeral_volume: Optional[List[str]] = typer.Option(
-            None,
-            help=
-            '''Takes 1 parameter Only                                           
+        """,
+    ),
+    ephemeral_volume: Optional[List[str]] = typer.Option(
+        None,
+        help="""Takes 1 parameter Only                                           
             Ephemeral volumes can move and be removed by the host,Garbage collected basically, when the VM isn't running                                  
             eg: Use , to seperate the parameters and no spaces                                                                      
-             --ephemeral-volume size_mib=100 ./my-program main:app '''),
-
-        immutable_volume: Optional[List[str]] = typer.Option(
-            None,
-            help=
-            '''Takes 3 parameters                                           
+             --ephemeral-volume size_mib=100 ./my-program main:app """,
+    ),
+    immutable_volume: Optional[List[str]] = typer.Option(
+        None,
+        help="""Takes 3 parameters                                           
              Immutable volume is one whose contents do not change                                   
              eg: Use , to seperate the parameters and no spaces                                                                      
             --immutable-volume ref=25a393222692c2f73489dc6710ae87605a96742ceef7b91de4d7ec34bb688d94,use_latest=true,mount=/mnt/volume ./my-program main:app
-             '''
-        )
-
+             """,
+    ),
 ):
     """Register a program to run on Aleph.im virtual machines from a zip archive."""
 
@@ -111,15 +106,19 @@ def upload(
     account: AccountFromPrivateKey = _load_account(private_key, private_key_file)
 
     runtime = (
-            runtime
-            or input(f"Ref of runtime ? [{settings.DEFAULT_RUNTIME_ID}] ")
-            or settings.DEFAULT_RUNTIME_ID
+        runtime
+        or input(f"Ref of runtime ? [{settings.DEFAULT_RUNTIME_ID}] ")
+        or settings.DEFAULT_RUNTIME_ID
     )
 
     volumes = []
 
     # Check if the volumes are empty
-    if persistent_volume is None or ephemeral_volume is None or immutable_volume is None:
+    if (
+        persistent_volume is None
+        or ephemeral_volume is None
+        or immutable_volume is None
+    ):
         for volume in prompt_for_volumes():
             volumes.append(volume)
             typer.echo("\n")
@@ -147,76 +146,71 @@ def upload(
     else:
         subscriptions = None
 
-    try:
-        # Upload the source code
-        with open(path_object, "rb") as fd:
-            logger.debug("Reading file")
-            # TODO: Read in lazy mode instead of copying everything in memory
-            file_content = fd.read()
-            storage_engine = (
-                StorageEnum.ipfs
-                if len(file_content) > 4 * 1024 * 1024
-                else StorageEnum.storage
-            )
-            logger.debug("Uploading file")
-            user_code: StoreMessage = synchronous.create_store(
-                account=account,
-                file_content=file_content,
-                storage_engine=storage_engine,
-                channel=channel,
-                guess_mime_type=True,
-                ref=None,
-            )
-            logger.debug("Upload finished")
-            if print_messages or print_code_message:
-                typer.echo(f"{user_code.json(indent=4)}")
-            program_ref = user_code.item_hash
-
-        # Register the program
-        message, status = synchronous.create_program(
+    # Upload the source code
+    with open(path_object, "rb") as fd:
+        logger.debug("Reading file")
+        # TODO: Read in lazy mode instead of copying everything in memory
+        file_content = fd.read()
+        storage_engine = (
+            StorageEnum.ipfs
+            if len(file_content) > 4 * 1024 * 1024
+            else StorageEnum.storage
+        )
+        logger.debug("Uploading file")
+        user_code: StoreMessage = synchronous.create_store(
             account=account,
-            program_ref=program_ref,
-            entrypoint=entrypoint,
-            runtime=runtime,
-            storage_engine=StorageEnum.storage,
+            file_content=file_content,
+            storage_engine=storage_engine,
             channel=channel,
-            memory=memory,
-            vcpus=vcpus,
-            timeout_seconds=timeout_seconds,
-            persistent=persistent,
-            encoding=encoding,
-            volumes=volumes,
-            subscriptions=subscriptions,
+            guess_mime_type=True,
+            ref=None,
         )
         logger.debug("Upload finished")
-        if print_messages or print_program_message:
-            typer.echo(f"{message.json(indent=4)}")
+        if print_messages or print_code_message:
+            typer.echo(f"{user_code.json(indent=4)}")
+        program_ref = user_code.item_hash
 
-        hash: str = message.item_hash
-        hash_base32 = b32encode(b16decode(hash.upper())).strip(b"=").lower().decode()
+    # Register the program
+    message, status = synchronous.create_program(
+        account=account,
+        program_ref=program_ref,
+        entrypoint=entrypoint,
+        runtime=runtime,
+        storage_engine=StorageEnum.storage,
+        channel=channel,
+        memory=memory,
+        vcpus=vcpus,
+        timeout_seconds=timeout_seconds,
+        persistent=persistent,
+        encoding=encoding,
+        volumes=volumes,
+        subscriptions=subscriptions,
+    )
+    logger.debug("Upload finished")
+    if print_messages or print_program_message:
+        typer.echo(f"{message.json(indent=4)}")
 
-        typer.echo(
-            f"Your program has been uploaded on Aleph .\n\n"
-            "Available on:\n"
-            f"  {settings.VM_URL_PATH.format(hash=hash)}\n"
-            f"  {settings.VM_URL_HOST.format(hash_base32=hash_base32)}\n"
-            "Visualise on:\n  https://explorer.aleph.im/address/"
-            f"{message.chain}/{message.sender}/message/PROGRAM/{hash}\n"
-        )
+    hash: str = message.item_hash
+    hash_base32 = b32encode(b16decode(hash.upper())).strip(b"=").lower().decode()
 
-    finally:
-        # Prevent aiohttp unclosed connector warning
-        asyncio.run(get_fallback_session().close())
+    typer.echo(
+        f"Your program has been uploaded on Aleph .\n\n"
+        "Available on:\n"
+        f"  {settings.VM_URL_PATH.format(hash=hash)}\n"
+        f"  {settings.VM_URL_HOST.format(hash_base32=hash_base32)}\n"
+        "Visualise on:\n  https://explorer.aleph.im/address/"
+        f"{message.chain}/{message.sender}/message/PROGRAM/{hash}\n"
+    )
 
 
 @app.command()
 def update(
-        hash: str,
-        path: Path,
-        private_key: Optional[str] = settings.PRIVATE_KEY_STRING,
-        private_key_file: Optional[Path] = settings.PRIVATE_KEY_FILE,
-        print_message: bool = True,
-        debug: bool = False,
+    hash: str,
+    path: Path,
+    private_key: Optional[str] = settings.PRIVATE_KEY_STRING,
+    private_key_file: Optional[Path] = settings.PRIVATE_KEY_FILE,
+    print_message: bool = True,
+    debug: bool = False,
 ):
     """Update the code of an existing program"""
 
@@ -225,59 +219,55 @@ def update(
     account = _load_account(private_key, private_key_file)
     path = path.absolute()
 
+    program_message: ProgramMessage = synchronous.get_message(
+        item_hash=hash, message_type=ProgramMessage
+    )
+    code_ref = program_message.content.code.ref
+    code_message: StoreMessage = synchronous.get_message(
+        item_hash=code_ref, message_type=StoreMessage
+    )
+
     try:
-        program_message: ProgramMessage = synchronous.get_message(
-            item_hash=hash, message_type=ProgramMessage
+        path, encoding = create_archive(path)
+    except BadZipFile:
+        typer.echo("Invalid zip archive")
+        raise typer.Exit(3)
+    except FileNotFoundError:
+        typer.echo("No such file or directory")
+        raise typer.Exit(4)
+
+    if encoding != program_message.content.code.encoding:
+        logger.error(
+            f"Code must be encoded with the same encoding as the previous version "
+            f"('{encoding}' vs '{program_message.content.code.encoding}'"
         )
-        code_ref = program_message.content.code.ref
-        code_message: StoreMessage = synchronous.get_message(
-            item_hash=code_ref, message_type=StoreMessage
+        raise typer.Exit(1)
+
+    # Upload the source code
+    with open(path, "rb") as fd:
+        logger.debug("Reading file")
+        # TODO: Read in lazy mode instead of copying everything in memory
+        file_content = fd.read()
+        logger.debug("Uploading file")
+        message, status = synchronous.create_store(
+            account=account,
+            file_content=file_content,
+            storage_engine=code_message.content.item_type,
+            channel=code_message.channel,
+            guess_mime_type=True,
+            ref=code_message.item_hash,
         )
-
-        try:
-            path, encoding = create_archive(path)
-        except BadZipFile:
-            typer.echo("Invalid zip archive")
-            raise typer.Exit(3)
-        except FileNotFoundError:
-            typer.echo("No such file or directory")
-            raise typer.Exit(4)
-
-        if encoding != program_message.content.code.encoding:
-            logger.error(
-                f"Code must be encoded with the same encoding as the previous version "
-                f"('{encoding}' vs '{program_message.content.code.encoding}'"
-            )
-            raise typer.Exit(1)
-
-        # Upload the source code
-        with open(path, "rb") as fd:
-            logger.debug("Reading file")
-            # TODO: Read in lazy mode instead of copying everything in memory
-            file_content = fd.read()
-            logger.debug("Uploading file")
-            message, status = synchronous.create_store(
-                account=account,
-                file_content=file_content,
-                storage_engine=code_message.content.item_type,
-                channel=code_message.channel,
-                guess_mime_type=True,
-                ref=code_message.item_hash,
-            )
-            logger.debug("Upload finished")
-            if print_message:
-                typer.echo(f"{message.json(indent=4)}")
-    finally:
-        # Prevent aiohttp unclosed connector warning
-        asyncio.run(get_fallback_session().close())
+        logger.debug("Upload finished")
+        if print_message:
+            typer.echo(f"{message.json(indent=4)}")
 
 
 @app.command()
 def unpersist(
-        hash: str,
-        private_key: Optional[str] = settings.PRIVATE_KEY_STRING,
-        private_key_file: Optional[Path] = settings.PRIVATE_KEY_FILE,
-        debug: bool = False,
+    hash: str,
+    private_key: Optional[str] = settings.PRIVATE_KEY_STRING,
+    private_key_file: Optional[Path] = settings.PRIVATE_KEY_FILE,
+    debug: bool = False,
 ):
     """Stop a persistent virtual machine by making it non-persistent"""
 

--- a/src/aleph_client/user_session.py
+++ b/src/aleph_client/user_session.py
@@ -1,0 +1,28 @@
+import asyncio
+
+import aiohttp
+
+from aleph_client.types import Account
+
+
+class UserSession:
+    account: Account
+    api_server: str
+    http_session: aiohttp.ClientSession
+
+    def __init__(self,  account: Account, api_server: str):
+        self.account = account
+        self.api_server = api_server
+        self.http_session = aiohttp.ClientSession(base_url=api_server)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        asyncio.run(self.http_session.close())
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.http_session.close()

--- a/tests/integration/itest_aggregates.py
+++ b/tests/integration/itest_aggregates.py
@@ -6,6 +6,7 @@ from aleph_client.asynchronous import (
     create_aggregate,
     fetch_aggregate,
 )
+from aleph_client.user_session import UserSession
 from tests.integration.toolkit import try_until
 from .config import REFERENCE_NODE, TARGET_NODE
 
@@ -20,13 +21,13 @@ async def create_aggregate_on_target(
     receiver_node: str,
     channel="INTEGRATION_TESTS",
 ):
-    aggregate_message, message_status = await create_aggregate(
-        account=account,
-        key=key,
-        content=content,
-        channel="INTEGRATION_TESTS",
-        api_server=emitter_node,
-    )
+    async with UserSession(account=account, api_server=emitter_node) as tx_session:
+        aggregate_message, message_status = await create_aggregate(
+            session=tx_session,
+            key=key,
+            content=content,
+            channel="INTEGRATION_TESTS",
+        )
 
     assert aggregate_message.sender == account.get_address()
     assert aggregate_message.channel == channel
@@ -39,14 +40,15 @@ async def create_aggregate_on_target(
     assert aggregate_message.content.address == account.get_address()
     assert aggregate_message.content.content == content
 
-    aggregate_from_receiver = await try_until(
-        fetch_aggregate,
-        lambda aggregate: aggregate is not None,
-        timeout=5,
-        address=account.get_address(),
-        key=key,
-        api_server=receiver_node,
-    )
+    async with UserSession(account=account, api_server=receiver_node) as rx_session:
+        aggregate_from_receiver = await try_until(
+            fetch_aggregate,
+            lambda aggregate: aggregate is not None,
+            session=rx_session,
+            timeout=5,
+            address=account.get_address(),
+            key=key,
+        )
 
     for key, value in content.items():
         assert key in aggregate_from_receiver

--- a/tests/integration/itest_forget.py
+++ b/tests/integration/itest_forget.py
@@ -4,6 +4,7 @@ import pytest
 
 from aleph_client.asynchronous import create_post, get_posts, get_messages, forget
 from aleph_client.types import Account
+from aleph_client.user_session import UserSession
 from .config import REFERENCE_NODE, TARGET_NODE, TEST_CHANNEL
 from .toolkit import try_until
 
@@ -12,24 +13,26 @@ async def create_and_forget_post(
     account: Account, emitter_node: str, receiver_node: str, channel=TEST_CHANNEL
 ) -> str:
     async def wait_matching_posts(
-        item_hash: str, condition: Callable[[Dict], bool], timeout: int = 5
+        item_hash: str,
+        condition: Callable[[Dict], bool],
+        timeout: int = 5,
     ):
-        return await try_until(
-            get_posts,
-            condition,
-            timeout=timeout,
-            hashes=[item_hash],
-            api_server=receiver_node,
-        )
+        async with UserSession(account=account, api_server=receiver_node) as rx_session:
+            return await try_until(
+                get_posts,
+                condition,
+                session=rx_session,
+                timeout=timeout,
+                hashes=[item_hash],
+            )
 
-    post_message, message_status = await create_post(
-        account=account,
-        post_content="A considerate and politically correct post.",
-        post_type="POST",
-        channel="INTEGRATION_TESTS",
-        session=None,
-        api_server=emitter_node,
-    )
+    async with UserSession(account=account, api_server=emitter_node) as tx_session:
+        post_message, message_status = await create_post(
+            session=tx_session,
+            post_content="A considerate and politically correct post.",
+            post_type="POST",
+            channel="INTEGRATION_TESTS",
+        )
 
     # Wait for the message to appear on the receiver. We don't check the values,
     # they're checked in other integration tests.
@@ -41,13 +44,13 @@ async def create_and_forget_post(
 
     post_hash = post_message.item_hash
     reason = "This well thought-out content offends me!"
-    forget_message, forget_status = await forget(
-        account,
-        hashes=[post_hash],
-        reason=reason,
-        channel=channel,
-        api_server=emitter_node,
-    )
+    async with UserSession(account=account, api_server=emitter_node) as tx_session:
+        forget_message, forget_status = await forget(
+            session=tx_session,
+            hashes=[post_hash],
+            reason=reason,
+            channel=channel,
+        )
 
     assert forget_message.sender == account.get_address()
     assert forget_message.content.reason == reason
@@ -97,26 +100,28 @@ async def test_forget_a_forget_message(fixture_account):
 
     # TODO: this test should be moved to the PyAleph API tests, once a framework is in place.
     post_hash = await create_and_forget_post(fixture_account, TARGET_NODE, TARGET_NODE)
-    get_post_response = await get_posts(hashes=[post_hash])
-    assert len(get_post_response["posts"]) == 1
-    post = get_post_response["posts"][0]
+    async with UserSession(account=fixture_account, api_server=TARGET_NODE) as session:
+        get_post_response = await get_posts(session=session, hashes=[post_hash])
+        assert len(get_post_response["posts"]) == 1
+        post = get_post_response["posts"][0]
 
-    forget_message_hash = post["forgotten_by"][0]
-    forget_message, forget_status = await forget(
-        fixture_account,
-        hashes=[forget_message_hash],
-        reason="I want to remember this post. Maybe I can forget I forgot it?",
-        channel=TEST_CHANNEL,
-        api_server=TARGET_NODE,
-    )
+        forget_message_hash = post["forgotten_by"][0]
+        forget_message, forget_status = await forget(
+            session=session,
+            hashes=[forget_message_hash],
+            reason="I want to remember this post. Maybe I can forget I forgot it?",
+            channel=TEST_CHANNEL,
+        )
 
-    print(forget_message)
+        print(forget_message)
 
-    get_forget_message_response = await get_messages(
-        hashes=[forget_message_hash], channels=[TEST_CHANNEL], api_server=TARGET_NODE
-    )
-    assert len(get_forget_message_response.messages) == 1
-    forget_message = get_forget_message_response.messages[0]
-    print(forget_message)
+        get_forget_message_response = await get_messages(
+            session=session,
+            hashes=[forget_message_hash],
+            channels=[TEST_CHANNEL],
+        )
+        assert len(get_forget_message_response.messages) == 1
+        forget_message = get_forget_message_response.messages[0]
+        print(forget_message)
 
-    assert "forgotten_by" not in forget_message
+        assert "forgotten_by" not in forget_message

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,20 +1,17 @@
-# -*- coding: utf-8 -*-
-"""
-    Dummy conftest.py for aleph_client.
-
-    If you don't know what this is for, just leave it empty.
-    Read more about conftest.py under:
-    https://pytest.org/latest/plugins.html
-"""
+import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-import pytest
+import pytest as pytest
 
-from aleph_client.chains.common import get_fallback_private_key
 import aleph_client.chains.ethereum as ethereum
 import aleph_client.chains.sol as solana
 import aleph_client.chains.tezos as tezos
+from aleph_client.chains.common import get_fallback_private_key
+from aleph_client.chains.ethereum import ETHAccount
+from aleph_client.conf import settings
+from aleph_client.types import Account
+
 
 @pytest.fixture
 def fallback_private_key() -> bytes:

--- a/tests/unit/test_asynchronous.py
+++ b/tests/unit/test_asynchronous.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import patch, AsyncMock
 
 import pytest as pytest
 from aleph_message.models import (
@@ -9,112 +9,93 @@ from aleph_message.models import (
     ForgetMessage,
 )
 
-from aleph_client.types import StorageEnum, MessageStatus
-
 from aleph_client.asynchronous import (
     create_post,
-    _get_fallback_session,
     create_aggregate,
     create_store,
     create_program,
     forget,
 )
+from aleph_client.types import StorageEnum, MessageStatus, Account
 
 
-def new_mock_session_with_post_success():
-    mock_response = AsyncMock()
-    mock_response.status = 200
+@pytest.fixture
+def mock_session_with_post_success(mocker, ethereum_account: Account):
+    mock_response = mocker.AsyncMock()
+    mock_response.status = 202
     mock_response.json.return_value = {
-        "message_status": "processed",
+        "message_status": "pending",
         "publication_status": {"status": "success", "failed": []},
     }
 
-    mock_post = AsyncMock()
+    mock_post = mocker.AsyncMock()
     mock_post.return_value = mock_response
 
-    mock_session = MagicMock()
+    mock_session = mocker.MagicMock()
     mock_session.post.return_value.__aenter__ = mock_post
-    return mock_session
+
+    user_session = mocker.AsyncMock()
+    user_session.http_session = mock_session
+    user_session.account = ethereum_account
+
+    return user_session
 
 
 @pytest.mark.asyncio
-async def test_create_post(ethereum_account):
-    _get_fallback_session.cache_clear()
+async def test_create_post(mock_session_with_post_success):
 
+    mock_session = mock_session_with_post_success
     content = {"Hello": "World"}
 
-    mock_session = new_mock_session_with_post_success()
-
     post_message, message_status = await create_post(
-        account=ethereum_account,
+        session=mock_session,
         post_content=content,
         post_type="TEST",
         channel="TEST",
-        session=mock_session,
-        api_server="https://example.org",
-        sync=True,
     )
 
-    assert mock_session.post.called
+    assert mock_session.http_session.post.called
     assert isinstance(post_message, PostMessage)
-    assert message_status == MessageStatus.PROCESSED
+    assert message_status == MessageStatus.PENDING
 
 
 @pytest.mark.asyncio
-async def test_create_aggregate(ethereum_account):
-    _get_fallback_session.cache_clear()
+async def test_create_aggregate(mock_session_with_post_success):
 
-    content = {"Hello": "World"}
-
-    mock_session = new_mock_session_with_post_success()
-
-    _ = await create_aggregate(
-        account=ethereum_account,
-        key="hello",
-        content=content,
-        channel="TEST",
-        session=mock_session,
-    )
+    mock_session = mock_session_with_post_success
 
     aggregate_message, message_status = await create_aggregate(
-        account=ethereum_account,
-        key="hello",
-        content="world",
-        channel="TEST",
         session=mock_session,
-        api_server="https://example.org",
+        key="hello",
+        content={"Hello": "world"},
+        channel="TEST",
     )
 
-    assert mock_session.post.called
+    assert mock_session.http_session.post.called
     assert isinstance(aggregate_message, AggregateMessage)
 
 
 @pytest.mark.asyncio
-async def test_create_store(ethereum_account):
-    _get_fallback_session.cache_clear()
+async def test_create_store(mock_session_with_post_success):
 
-    mock_session = new_mock_session_with_post_success()
+    mock_session = mock_session_with_post_success
 
     mock_ipfs_push_file = AsyncMock()
     mock_ipfs_push_file.return_value = "QmRTV3h1jLcACW4FRfdisokkQAk4E4qDhUzGpgdrd4JAFy"
 
     with patch("aleph_client.asynchronous.ipfs_push_file", mock_ipfs_push_file):
         _ = await create_store(
-            account=ethereum_account,
+            session=mock_session,
             file_content=b"HELLO",
             channel="TEST",
             storage_engine=StorageEnum.ipfs,
-            session=mock_session,
-            api_server="https://example.org",
         )
 
         _ = await create_store(
-            account=ethereum_account,
+            session=mock_session,
             file_hash="QmRTV3h1jLcACW4FRfdisokkQAk4E4qDhUzGpgdrd4JAFy",
             channel="TEST",
             storage_engine=StorageEnum.ipfs,
-            session=mock_session,
-            api_server="https://example.org",
         )
 
     mock_storage_push_file = AsyncMock()
@@ -123,54 +104,45 @@ async def test_create_store(ethereum_account):
     )
 
     with patch("aleph_client.asynchronous.storage_push_file", mock_storage_push_file):
-
         store_message, message_status = await create_store(
-            account=ethereum_account,
+            session=mock_session,
             file_content=b"HELLO",
             channel="TEST",
             storage_engine=StorageEnum.storage,
-            session=mock_session,
-            api_server="https://example.org",
         )
 
-    assert mock_session.post.called
+    assert mock_session.http_session.post.called
     assert isinstance(store_message, StoreMessage)
 
 
 @pytest.mark.asyncio
-async def test_create_program(ethereum_account):
-    _get_fallback_session.cache_clear()
+async def test_create_program(mock_session_with_post_success):
 
-    mock_session = new_mock_session_with_post_success()
+    mock_session = mock_session_with_post_success
 
     program_message, message_status = await create_program(
-        account=ethereum_account,
+        session=mock_session,
         program_ref="FAKE-HASH",
         entrypoint="main:app",
         runtime="FAKE-HASH",
         channel="TEST",
-        session=mock_session,
-        api_server="https://example.org",
     )
 
-    assert mock_session.post.called
+    assert mock_session.http_session.post.called
     assert isinstance(program_message, ProgramMessage)
 
 
 @pytest.mark.asyncio
-async def test_forget(ethereum_account):
-    _get_fallback_session.cache_clear()
+async def test_forget(mock_session_with_post_success):
 
-    mock_session = new_mock_session_with_post_success()
+    mock_session = mock_session_with_post_success
 
     forget_message, message_status = await forget(
-        account=ethereum_account,
+        session=mock_session,
         hashes=["QmRTV3h1jLcACW4FRfdisokkQAk4E4qDhUzGpgdrd4JAFy"],
         reason="GDPR",
         channel="TEST",
-        session=mock_session,
-        api_server="https://example.org",
     )
 
-    assert mock_session.post.called
+    assert mock_session.http_session.post.called
     assert isinstance(forget_message, ForgetMessage)

--- a/tests/unit/test_asynchronous_get.py
+++ b/tests/unit/test_asynchronous_get.py
@@ -1,64 +1,98 @@
+import unittest
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 from aleph_message.models import MessageType, MessagesResponse
-import unittest
 
 from aleph_client.asynchronous import (
     get_messages,
     fetch_aggregates,
     fetch_aggregate,
-    _get_fallback_session,
 )
+from aleph_client.conf import settings
+from aleph_client.types import Account
+from aleph_client.user_session import UserSession
+
+
+def make_mock_session(mock_account: Account, get_return_value: Dict[str, Any]):
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(side_effect=lambda: get_return_value)
+
+    mock_get = AsyncMock()
+    mock_get.return_value = mock_response
+
+    mock_session = MagicMock()
+    mock_session.get.return_value.__aenter__ = mock_get
+
+    user_session = AsyncMock()
+    user_session.http_session = mock_session
+    user_session.account = mock_account
+
+    return user_session
 
 
 @pytest.mark.asyncio
-async def test_fetch_aggregate():
-    _get_fallback_session.cache_clear()
+async def test_fetch_aggregate(ethereum_account: Account):
+    mock_session = make_mock_session(
+        ethereum_account, {"data": {"corechannel": {"nodes": [], "resource_nodes": []}}}
+    )
 
     response = await fetch_aggregate(
-        address="0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10", key="corechannel"
+        session=mock_session,
+        address="0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10",
+        key="corechannel",
     )
     assert response.keys() == {"nodes", "resource_nodes"}
 
 
 @pytest.mark.asyncio
-async def test_fetch_aggregates():
-    _get_fallback_session.cache_clear()
+async def test_fetch_aggregates(ethereum_account: Account):
+    mock_session = make_mock_session(
+        ethereum_account, {"data": {"corechannel": {"nodes": [], "resource_nodes": []}}}
+    )
 
     response = await fetch_aggregates(
-        address="0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10"
+        session=mock_session, address="0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10"
     )
     assert response.keys() == {"corechannel"}
     assert response["corechannel"].keys() == {"nodes", "resource_nodes"}
 
 
 @pytest.mark.asyncio
-async def test_get_posts():
-    _get_fallback_session.cache_clear()
+async def test_get_posts(ethereum_account: Account):
+    async with UserSession(
+        account=ethereum_account, api_server=settings.API_HOST
+    ) as session:
+        response: MessagesResponse = await get_messages(
+            session=session,
+            pagination=2,
+            message_type=MessageType.post,
+        )
 
-    response: MessagesResponse = await get_messages(
-        pagination=2,
-        message_type=MessageType.post,
-    )
-
-    messages = response.messages
-    assert len(messages) > 1
-    for message in messages:
-        assert message.type == MessageType.post
+        messages = response.messages
+        assert len(messages) > 1
+        for message in messages:
+            assert message.type == MessageType.post
 
 
 @pytest.mark.asyncio
-async def test_get_messages():
-    _get_fallback_session.cache_clear()
+async def test_get_messages(ethereum_account: Account):
+    async with UserSession(
+        account=ethereum_account, api_server=settings.API_HOST
+    ) as session:
+        response: MessagesResponse = await get_messages(
+            session=session,
+            pagination=2,
+        )
 
-    response: MessagesResponse = await get_messages(
-        pagination=2,
-    )
-
-    messages = response.messages
-    assert len(messages) > 1
-    assert messages[0].type
-    assert messages[0].sender
+        messages = response.messages
+        assert len(messages) > 1
+        assert messages[0].type
+        assert messages[0].sender
 
 
-if __name__ == '__main __':
+if __name__ == "__main __":
     unittest.main()

--- a/tests/unit/test_synchronous_get.py
+++ b/tests/unit/test_synchronous_get.py
@@ -1,0 +1,20 @@
+from aleph_message.models import MessageType, MessagesResponse
+
+from aleph_client.conf import settings
+from aleph_client.synchronous import get_messages
+from aleph_client.types import Account
+from aleph_client.user_session import UserSession
+
+
+def test_get_posts(mock_account: Account):
+    with UserSession(account=mock_account, api_server=settings.API_HOST) as session:
+        response: MessagesResponse = get_messages(
+            session=session,
+            pagination=2,
+            message_type=MessageType.post,
+        )
+
+        messages = response.messages
+        assert len(messages) > 1
+        for message in messages:
+            assert message.type == MessageType.post

--- a/tests/unit/test_vm_cache.py
+++ b/tests/unit/test_vm_cache.py
@@ -1,3 +1,4 @@
+import aiohttp
 import pytest
 
 from aleph_client.vm.cache import TestVmCache, sanitize_cache_key
@@ -5,6 +6,8 @@ from aleph_client.vm.cache import TestVmCache, sanitize_cache_key
 
 @pytest.mark.asyncio
 async def test_local_vm_cache():
+    http_session = aiohttp.ClientSession(base_url="http://localhost:8000")
+
     cache = TestVmCache()
     assert (await cache.get("doesnotexist")) is None
     assert len(await (cache.keys())) == 0


### PR DESCRIPTION
Problem: we often pass 2-3 objects to each function that represent information on how to connect to the Aleph network:

* the user account
* the API server URL
* the aiohttp session.

This can be simplified to improve the user experience and reduce the complexity of the SDK.

Solution: introduce a new state class: `UserSession`. This object is now passed as the first parameter of every public function. It is initialized with the user account and the API server URL. It is in charge of configuring and managing the aiohttp session object.

The typical usage of the library now looks like this:

```
account = load_my_account()
api_server = "https://aleph.cloud"  # example
async with UserSession(account=account, api_server=api_server) as session:
  message, status = await create_post(
    session=session,
    ...
  )
```

This enables the following improvements:

* Less clutter in function signatures: all public SDK functions now have 1 or 2 fewer arguments.
* The API server URL is now managed when initializing the aiohttp session inside the user session object. Implementations can simply specify the endpoint URL. Ex: `f"{api_server}/api/v0/messages.json` can now be expressed as `"/api/v0/messages.json"`.

Breaking changes:

* The signatures of all public functions of the SDK have been modified. The user must now initialize the user session object and pass it as parameter.