### PR TITLE
Fix: remove aiohttp from TestVmCache __init__()

### DIFF
--- a/src/aleph_client/vm/cache.py
+++ b/src/aleph_client/vm/cache.py
@@ -21,8 +21,6 @@ def sanitize_cache_key(key: str) -> CacheKey:
 class BaseVmCache(abc.ABC):
     """Virtual Machines can use this cache to store temporary data in memory on the host."""
 
-    session: ClientSession
-
     @abc.abstractmethod
     async def get(self, key: str) -> Optional[bytes]:
         """Get the value for a given key string."""
@@ -47,6 +45,7 @@ class BaseVmCache(abc.ABC):
 class VmCache(BaseVmCache):
     """Virtual Machines can use this cache to store temporary data in memory on the host."""
 
+    session: ClientSession
     cache: Dict[str, bytes]
     api_host: str
 

--- a/src/aleph_client/vm/cache.py
+++ b/src/aleph_client/vm/cache.py
@@ -23,9 +23,6 @@ class BaseVmCache(abc.ABC):
 
     session: ClientSession
 
-    def __init__(self, session: Optional[ClientSession] = None):
-        self.session = session or get_fallback_session()
-
     @abc.abstractmethod
     async def get(self, key: str) -> Optional[bytes]:
         """Get the value for a given key string."""
@@ -54,7 +51,7 @@ class VmCache(BaseVmCache):
     api_host: str
 
     def __init__(self, session: Optional[ClientSession] = None, api_host: Optional[str] = None):
-        super().__init__(session)
+        self.session = session or get_fallback_session()
         self.cache = {}
         self.api_host = api_host if api_host else settings.API_HOST
 
@@ -97,8 +94,7 @@ class VmCache(BaseVmCache):
 class TestVmCache(BaseVmCache):
     """This is a local, dict-based cache that can be used for testing purposes."""
 
-    def __init__(self, session: Optional[ClientSession] = None):
-        super().__init__(session)
+    def __init__(self):
         self._cache: Dict[str, bytes] = {}
 
     async def get(self, key: str) -> Optional[bytes]:


### PR DESCRIPTION
Problem: the aiohttp session is not required in this object. Solution: remove it from the base class constructor and use it only for the real VM cache.