### PR TITLE
Fix: generate valid signatures with Python 3.11

### DIFF
--- a/src/aleph_client/commands/files.py
+++ b/src/aleph_client/commands/files.py
@@ -86,7 +86,7 @@ def upload(
                 else StorageEnum.storage
             )
             logger.debug("Uploading file")
-            result: StoreMessage = synchronous.create_store(
+            message, status = synchronous.create_store(
                 account=account,
                 file_content=file_content,
                 storage_engine=storage_engine,
@@ -95,7 +95,7 @@ def upload(
                 ref=ref,
             )
             logger.debug("Upload finished")
-            typer.echo(f"{result.json(indent=4)}")
+            typer.echo(f"{message.json(indent=4)}")
     finally:
         # Prevent aiohttp unclosed connector warning
         asyncio.run(get_fallback_session().close())


### PR DESCRIPTION
Problem: signatures generated with Python 3.11 are invalid. The signature buffer is affected by the new formatting of string enums.

Solution: use the value of the message type enum.