### PR TITLE
Fix: broken post/store message publication commands

### DIFF
--- a/src/aleph_client/commands/files.py
+++ b/src/aleph_client/commands/files.py
@@ -38,7 +38,7 @@ def pin(
     account: AccountFromPrivateKey = _load_account(private_key, private_key_file)
 
     try:
-        result: StoreMessage = synchronous.create_store(
+        message, status = synchronous.create_store(
             account=account,
             file_hash=hash,
             storage_engine=StorageEnum.ipfs,
@@ -46,7 +46,7 @@ def pin(
             ref=ref,
         )
         logger.debug("Upload finished")
-        typer.echo(f"{result.json(indent=4)}")
+        typer.echo(f"{message.json(indent=4)}")
     finally:
         # Prevent aiohttp unclosed connector warning
         asyncio.run(get_fallback_session().close())
@@ -86,7 +86,7 @@ def upload(
                 else StorageEnum.storage
             )
             logger.debug("Uploading file")
-            result: StoreMessage = synchronous.create_store(
+            message, status = synchronous.create_store(
                 account=account,
                 file_content=file_content,
                 storage_engine=storage_engine,
@@ -95,7 +95,7 @@ def upload(
                 ref=ref,
             )
             logger.debug("Upload finished")
-            typer.echo(f"{result.json(indent=4)}")
+            typer.echo(f"{message.json(indent=4)}")
     finally:
         # Prevent aiohttp unclosed connector warning
         asyncio.run(get_fallback_session().close())

--- a/src/aleph_client/commands/message.py
+++ b/src/aleph_client/commands/message.py
@@ -80,7 +80,7 @@ def post(
             raise typer.Exit(code=2)
 
     try:
-        result: PostMessage = synchronous.create_post(
+        message, status = synchronous.create_post(
             account=account,
             post_content=content,
             post_type=type,
@@ -89,7 +89,7 @@ def post(
             inline=True,
             storage_engine=storage_engine,
         )
-        typer.echo(result.json(indent=4))
+        typer.echo(message.json(indent=4))
     finally:
         # Prevent aiohttp unclosed connector warning
         asyncio.run(get_fallback_session().close())
@@ -154,13 +154,13 @@ def forget_messages(
         channel: str,
 ):
     try:
-        result: ForgetMessage = synchronous.forget(
+        message, status = synchronous.forget(
             account=account,
             hashes=hashes,
             reason=reason,
             channel=channel,
         )
-        typer.echo(f"{result.json(indent=4)}")
+        typer.echo(f"{message.json(indent=4)}")
     finally:
         # Prevent aiohttp unclosed connector warning
         asyncio.run(get_fallback_session().close())


### PR DESCRIPTION
Problem: the synchronous versions of `create_post`/`create_store`/`forget` were not using the new return value type (a tuple containing the message + its status instead of just the message).

Solution: fixed all usages.