### PR TITLE
Use latest post-v0.7.0 SDK - fix breaking changes

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -22,6 +22,13 @@ jobs:
           brew update
           brew tap cuber/homebrew-libsecp256k1
           brew install libsecp256k1
+
+      - name: Set up Python for macOS
+        if: startsWith(matrix.os, 'macos')
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+
       
       - name: Install required system packages only for Ubuntu Linux
         if: startsWith(matrix.os, 'ubuntu-')

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ package_dir =
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires =
-    aleph-sdk-python==0.7.0
+    aleph-sdk-python@git+https://github.com/aleph-im/aleph-sdk-python.git@main
     aleph-message==0.4.0
     coincurve
     aiohttp>=3.8.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ package_dir =
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires =
-    aleph-sdk-python@git+https://github.com/aleph-im/aleph-sdk-python.git@main
+    aleph-sdk-python==0.7.0
     aleph-message==0.4.0
     coincurve
     aiohttp>=3.8.3

--- a/src/aleph_client/__main__.py
+++ b/src/aleph_client/__main__.py
@@ -4,9 +4,11 @@ Aleph Client command-line interface.
 
 import typer
 
+from aleph_client.utils import AsyncTyper
 from .commands import about, account, aggregate, files, message, program
 
-app = typer.Typer()
+app = AsyncTyper()
+
 
 @app.callback()
 def common(
@@ -15,6 +17,7 @@ def common(
     v: bool = typer.Option(None, "-v", callback=about.get_version, help="Show Aleph CLI Version"),
 ):
     pass
+
 
 app.add_typer(account.app, name="account", help="Manage account")
 app.add_typer(

--- a/src/aleph_client/commands/about.py
+++ b/src/aleph_client/commands/about.py
@@ -1,7 +1,9 @@
 import typer
 from pkg_resources import get_distribution
 
-app = typer.Typer()
+from aleph_client.utils import AsyncTyper
+
+app = AsyncTyper()
 
 
 def get_version(value: bool):

--- a/src/aleph_client/commands/account.py
+++ b/src/aleph_client/commands/account.py
@@ -15,9 +15,10 @@ from typer.colors import RED
 
 from aleph_client.commands import help_strings
 from aleph_client.commands.utils import setup_logging
+from aleph_client.utils import AsyncTyper
 
 logger = logging.getLogger(__name__)
-app = typer.Typer()
+app = AsyncTyper()
 
 
 @app.command()

--- a/src/aleph_client/commands/aggregate.py
+++ b/src/aleph_client/commands/aggregate.py
@@ -10,8 +10,9 @@ from aleph_message.models import MessageType
 
 from aleph_client.commands import help_strings
 from aleph_client.commands.utils import setup_logging
+from aleph_client.utils import AsyncTyper
 
-app = typer.Typer()
+app = AsyncTyper()
 
 
 @app.command()

--- a/src/aleph_client/commands/aggregate.py
+++ b/src/aleph_client/commands/aggregate.py
@@ -3,9 +3,10 @@ from typing import Optional
 
 import typer
 from aleph.sdk.account import _load_account
-from aleph.sdk.client import AuthenticatedAlephClient
+from aleph.sdk.client import AuthenticatedAlephHttpClient
 from aleph.sdk.conf import settings as sdk_settings
 from aleph.sdk.types import AccountFromPrivateKey
+from aleph.sdk.query.filters import MessageFilter
 from aleph_message.models import MessageType
 
 from aleph_client.commands import help_strings
@@ -16,7 +17,7 @@ app = AsyncTyper()
 
 
 @app.command()
-def forget(
+async def forget(
     key: str = typer.Argument(..., help="Aggregate item hash to be removed."),
     reason: Optional[str] = typer.Option(
         None, help="A description of why the messages are being forgotten"
@@ -36,14 +37,16 @@ def forget(
 
     account: AccountFromPrivateKey = _load_account(private_key, private_key_file)
 
-    with AuthenticatedAlephClient(
+    async with AuthenticatedAlephHttpClient(
         account=account, api_server=sdk_settings.API_HOST
     ) as client:
-        message_response = client.get_messages(
-            addresses=[account.get_address()],
-            message_type=MessageType.aggregate.value,
-            content_keys=[key],
+        message_response = await client.get_messages(
+            message_filter=MessageFilter(
+                addresses=[account.get_address()],
+                message_types=[MessageType.aggregate.value],
+                content_keys=[key],
+            )
         )
         hash_list = [message["item_hash"] for message in message_response.messages]
 
-        client.forget(hashes=hash_list, reason=reason, channel=channel)
+        await client.forget(hashes=hash_list, reason=reason, channel=channel)

--- a/src/aleph_client/commands/files.py
+++ b/src/aleph_client/commands/files.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 import typer
-from aleph.sdk import AuthenticatedAlephClient
+from aleph.sdk import AuthenticatedAlephHttpClient
 from aleph.sdk.account import _load_account
 from aleph.sdk.conf import settings as sdk_settings
 from aleph.sdk.types import AccountFromPrivateKey, StorageEnum
@@ -12,9 +12,10 @@ from aleph_message.status import MessageStatus
 
 from aleph_client.commands import help_strings
 from aleph_client.commands.utils import setup_logging
+from aleph_client.utils import AsyncTyper
 
 logger = logging.getLogger(__name__)
-app = typer.Typer()
+app = AsyncTyper()
 
 
 @app.command()
@@ -36,7 +37,7 @@ def pin(
 
     account: AccountFromPrivateKey = _load_account(private_key, private_key_file)
 
-    with AuthenticatedAlephClient(
+    with AuthenticatedAlephHttpClient(
         account=account, api_server=sdk_settings.API_HOST
     ) as client:
         result: StoreMessage
@@ -70,7 +71,7 @@ def upload(
 
     account: AccountFromPrivateKey = _load_account(private_key, private_key_file)
 
-    with AuthenticatedAlephClient(
+    with AuthenticatedAlephHttpClient(
         account=account, api_server=sdk_settings.API_HOST
     ) as client:
         if not path.is_file():

--- a/src/aleph_client/commands/files.py
+++ b/src/aleph_client/commands/files.py
@@ -19,7 +19,7 @@ app = AsyncTyper()
 
 
 @app.command()
-def pin(
+async def pin(
     item_hash: str = typer.Argument(..., help="IPFS hash to pin on aleph.im"),
     channel: Optional[str] = typer.Option(default=None, help=help_strings.CHANNEL),
     private_key: Optional[str] = typer.Option(
@@ -37,12 +37,12 @@ def pin(
 
     account: AccountFromPrivateKey = _load_account(private_key, private_key_file)
 
-    with AuthenticatedAlephHttpClient(
+    async with AuthenticatedAlephHttpClient(
         account=account, api_server=sdk_settings.API_HOST
     ) as client:
         result: StoreMessage
         status: MessageStatus
-        result, status = client.create_store(
+        result, status = await client.create_store(
             file_hash=item_hash,
             storage_engine=StorageEnum.ipfs,
             channel=channel,
@@ -53,7 +53,7 @@ def pin(
 
 
 @app.command()
-def upload(
+async def upload(
     path: Path = typer.Argument(..., help="Path of the file to upload"),
     channel: Optional[str] = typer.Option(default=None, help=help_strings.CHANNEL),
     private_key: Optional[str] = typer.Option(
@@ -71,7 +71,7 @@ def upload(
 
     account: AccountFromPrivateKey = _load_account(private_key, private_key_file)
 
-    with AuthenticatedAlephHttpClient(
+    async with AuthenticatedAlephHttpClient(
         account=account, api_server=sdk_settings.API_HOST
     ) as client:
         if not path.is_file():
@@ -90,7 +90,7 @@ def upload(
             logger.debug("Uploading file")
             result: StoreMessage
             status: MessageStatus
-            result, status = client.create_store(
+            result, status = await client.create_store(
                 file_content=file_content,
                 storage_engine=storage_engine,
                 channel=channel,

--- a/src/aleph_client/commands/program.py
+++ b/src/aleph_client/commands/program.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 from zipfile import BadZipFile
 
 import typer
-from aleph.sdk import AuthenticatedAlephClient
+from aleph.sdk import AuthenticatedAlephHttpClient
 from aleph.sdk.account import _load_account
 from aleph.sdk.conf import settings as sdk_settings
 from aleph.sdk.types import AccountFromPrivateKey, StorageEnum
@@ -28,10 +28,10 @@ from aleph_client.commands.utils import (
     yes_no_input,
 )
 from aleph_client.conf import settings
-from aleph_client.utils import create_archive
+from aleph_client.utils import create_archive, AsyncTyper
 
 logger = logging.getLogger(__name__)
-app = typer.Typer()
+app = AsyncTyper()
 
 
 @app.command()
@@ -147,7 +147,7 @@ def upload(
     else:
         subscriptions = None
 
-    with AuthenticatedAlephClient(
+    with AuthenticatedAlephHttpClient(
         account=account, api_server=sdk_settings.API_HOST
     ) as client:
         # Upload the source code
@@ -225,7 +225,7 @@ def update(
     account = _load_account(private_key, private_key_file)
     path = path.absolute()
 
-    with AuthenticatedAlephClient(
+    with AuthenticatedAlephHttpClient(
         account=account, api_server=sdk_settings.API_HOST
     ) as client:
         program_message: ProgramMessage = client.get_message(
@@ -283,7 +283,7 @@ def unpersist(
 
     account = _load_account(private_key, private_key_file)
 
-    with AuthenticatedAlephClient(
+    with AuthenticatedAlephHttpClient(
         account=account, api_server=sdk_settings.API_HOST
     ) as client:
         existing: MessagesResponse = client.get_messages(hashes=[item_hash])

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -1,9 +1,8 @@
 import json
-import subprocess
 from pathlib import Path
-from aleph.sdk.chains.ethereum import ETHAccount
 from tempfile import NamedTemporaryFile
 
+from aleph.sdk.chains.ethereum import ETHAccount
 from typer.testing import CliRunner
 
 from aleph_client.__main__ import app
@@ -55,9 +54,7 @@ def test_account_export_private_key(account_file: Path):
 
 
 def test_account_path():
-    result = runner.invoke(
-        app, ["account", "path"]
-    )
+    result = runner.invoke(app, ["account", "path"])
     assert result.stdout.startswith("/")
 
 
@@ -65,23 +62,22 @@ def test_message_get():
     # Use subprocess to avoid border effects between tests caused by the initialisation
     # of the aiohttp client session out of an async context in the SDK. This avoids
     # a "no running event loop" error when running several tests back to back.
-    result = subprocess.run(
+    result = runner.invoke(
+        app,
         [
-            "aleph",
             "message",
             "get",
             "bd79839bf96e595a06da5ac0b6ba51dea6f7e2591bb913deccded04d831d29f4",
         ],
-        capture_output=True,
     )
-    assert result.returncode == 0
-    assert b"0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9" in result.stdout
+    assert result.exit_code == 0
+    assert "0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9" in result.stdout
 
 
 def test_message_find():
-    result = subprocess.run(
+    result = runner.invoke(
+        app,
         [
-            "aleph",
             "message",
             "find",
             "--pagination=1",
@@ -90,12 +86,11 @@ def test_message_find():
             "--chains=ETH",
             "--hashes=bd79839bf96e595a06da5ac0b6ba51dea6f7e2591bb913deccded04d831d29f4",
         ],
-        capture_output=True,
     )
-    assert result.returncode == 0
-    assert b"0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9" in result.stdout
+    assert result.exit_code == 0
+    assert "0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9" in result.stdout
     assert (
-        b"bd79839bf96e595a06da5ac0b6ba51dea6f7e2591bb913deccded04d831d29f4"
+        "bd79839bf96e595a06da5ac0b6ba51dea6f7e2591bb913deccded04d831d29f4"
         in result.stdout
     )
 
@@ -103,9 +98,9 @@ def test_message_find():
 def test_sign_message(account_file):
     account = get_account(account_file)
     message = get_test_message(account)
-    result = subprocess.run(
+    result = runner.invoke(
+        app,
         [
-            "aleph",
             "message",
             "sign",
             "--private-key-file",
@@ -113,59 +108,67 @@ def test_sign_message(account_file):
             "--message",
             json.dumps(message),
         ],
-        capture_output=True,
     )
 
-    assert result.returncode == 0
-    assert b"signature" in result.stdout
+    assert result.exit_code == 0
+    assert "signature" in result.stdout
 
 
 def test_sign_message_stdin(account_file):
     account = get_account(account_file)
     message = get_test_message(account)
-    cmd = f"""echo '{json.dumps(message)}' | aleph message sign --private-key-file {account_file}"""
-    result = subprocess.run(cmd, shell=True, capture_output=True)
+    result = runner.invoke(
+        app,
+        [
+            "message",
+            "sign",
+            "--private-key-file",
+            str(account_file),
+        ],
+        input=json.dumps(message),
+    )
 
-    assert result.returncode == 0
-    assert b"signature" in result.stdout
+    assert result.exit_code == 0
+    assert "signature" in result.stdout
 
 
 def test_sign_raw():
-    result = subprocess.run(
+    result = runner.invoke(
+        app,
         [
-            "aleph",
             "account",
             "sign-bytes",
             "--message",
             "some message",
         ],
-        capture_output=True,
     )
 
-    assert result.returncode == 0
-    assert b"0x" in result.stdout
+    assert result.exit_code == 0
+    assert "0x" in result.stdout
 
 
 def test_sign_raw_stdin():
-    cmd = 'echo "some message" | aleph account sign-bytes'
-    result = subprocess.run(cmd, shell=True, capture_output=True)
+    message = "some message"
+    result = runner.invoke(
+        app,
+        [
+            "account",
+            "sign-bytes",
+        ],
+        input=message,
+    )
 
-    assert result.returncode == 0
-    assert b"0x" in result.stdout
+    assert result.exit_code == 0
+    assert "0x" in result.stdout
 
 
 def test_file_upload():
     #  Test upload a file to aleph network by creating a file and upload it to an aleph node
     with NamedTemporaryFile() as temp_file:
         temp_file.write(b"Hello World \n")
-        result = subprocess.run(
-            [
-                "aleph",
-                "file",
-                "upload",
-                temp_file.name
-            ],
-            capture_output=True,
+        result = runner.invoke(
+            app,
+            ["file", "upload", temp_file.name],
         )
-        assert result.returncode == 0
+        assert result.exit_code == 0
         assert result.stdout is not None


### PR DESCRIPTION
PR #164, which has recently been merged, used the latest main branch of `aleph-sdk-python`. There have been further breaking changes since the last CI/CD run of that PR, so a broken branch has mistakenly been merged into this repo's master branch.

This PR solves multiple issues:
- Use new `MessageFilter` and `PostFilter` properties and other changes to the `AlephClient` and `AuthenticatedAlephClient` interfaces.
- Introduce an `AsyncTyper` class to accommodate for the fact that `aleph-sdk-python` removed sync wrappers for the client classes.
- Fixes a MacOS CI/CD issue, forcing it to use Python 3.11 instead of 3.12.