### PR TITLE
Fix `test_build.yml` workflow

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,6 +1,12 @@
 name: Build source and wheel packages
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build: 


### PR DESCRIPTION
Fix test-build.yml to:
- only trigger on pushes to master
- trigger the workflow on any PR to master, this fixes @1yam's issues of forked repositories making a PR

`test-pytest.yml` remains the same, it will trigger on any push and on all PRs to master.