### PR TITLE
Fix missing `requests` dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     eth_account>=0.4.0
     python-magic
     pygments
+    requests
     rich
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
@@ -70,7 +71,6 @@ testing =
     fastapi
     # httpx is required in tests by fastapi.testclient
     httpx
-    requests
     types-requests
     aleph-pytezos==0.1.0
     types-setuptools


### PR DESCRIPTION
Was previously installed only when testing