### PR TITLE
Replace all usages of `requests` module with `aiohttp`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires =
     aleph-sdk-python@git+https://github.com/aleph-im/aleph-sdk-python.git@main
-    aleph-message==0.4.1
+    aleph-message==0.4.0
     coincurve
     aiohttp>=3.8.3
     eciespy

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     eth_account>=0.4.0
     python-magic
     pygments
-    requests
     rich
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires =
     aleph-sdk-python@git+https://github.com/aleph-im/aleph-sdk-python.git@main
-    aleph-message==0.4.0
+    aleph-message==0.4.1
     coincurve
     aiohttp>=3.8.3
     eciespy


### PR DESCRIPTION
As we are now using `AsyncTyper`, we can freely use async `aiohttp`-style requests everywhere