### PR TITLE
Fix relative import in `__main__.py`

### DIFF
--- a/src/aleph_client/__main__.py
+++ b/src/aleph_client/__main__.py
@@ -4,7 +4,7 @@ Aleph Client command-line interface.
 
 from aleph_client.utils import AsyncTyper
 
-from .commands import (
+from aleph_client.commands import (
     about,
     account,
     aggregate,


### PR DESCRIPTION
Having relative imports would break commands like:
```shell
typer ./src/aleph-client/__main__.py utils docs
```

Discovered when generating docs for https://github.com/aleph-im/aleph-docs/pull/75