### PR TITLE
Fix: Passing to arg did not show help

### DIFF
--- a/src/aleph_client/__main__.py
+++ b/src/aleph_client/__main__.py
@@ -16,7 +16,7 @@ from aleph_client.commands import (
     program,
 )
 
-app = AsyncTyper()
+app = AsyncTyper(no_args_is_help=True)
 
 app.add_typer(account.app, name="account", help="Manage account")
 app.add_typer(

--- a/src/aleph_client/commands/about.py
+++ b/src/aleph_client/commands/about.py
@@ -3,7 +3,7 @@ from pkg_resources import get_distribution
 
 from aleph_client.utils import AsyncTyper
 
-app = AsyncTyper()
+app = AsyncTyper(no_args_is_help=True)
 
 
 def get_version(value: bool):

--- a/src/aleph_client/commands/account.py
+++ b/src/aleph_client/commands/account.py
@@ -21,7 +21,7 @@ from aleph_client.commands.utils import setup_logging
 from aleph_client.utils import AsyncTyper
 
 logger = logging.getLogger(__name__)
-app = AsyncTyper()
+app = AsyncTyper(no_args_is_help=True)
 
 
 @app.command()

--- a/src/aleph_client/commands/aggregate.py
+++ b/src/aleph_client/commands/aggregate.py
@@ -15,7 +15,7 @@ from aleph_client.commands import help_strings
 from aleph_client.commands.utils import setup_logging
 from aleph_client.utils import AsyncTyper
 
-app = AsyncTyper()
+app = AsyncTyper(no_args_is_help=True)
 
 
 @app.command()

--- a/src/aleph_client/commands/domain.py
+++ b/src/aleph_client/commands/domain.py
@@ -25,7 +25,7 @@ from aleph_client.commands import help_strings
 from aleph_client.commands.utils import is_environment_interactive
 from aleph_client.utils import AsyncTyper
 
-app = AsyncTyper()
+app = AsyncTyper(no_args_is_help=True)
 
 
 async def get_aggregate_domain_info(account, fqdn):

--- a/src/aleph_client/commands/files.py
+++ b/src/aleph_client/commands/files.py
@@ -22,7 +22,7 @@ from aleph_client.commands.utils import setup_logging
 from aleph_client.utils import AsyncTyper
 
 logger = logging.getLogger(__name__)
-app = AsyncTyper()
+app = AsyncTyper(no_args_is_help=True)
 
 
 @app.command()

--- a/src/aleph_client/commands/instance.py
+++ b/src/aleph_client/commands/instance.py
@@ -33,7 +33,7 @@ from aleph_client.conf import settings
 from aleph_client.utils import AsyncTyper
 
 logger = logging.getLogger(__name__)
-app = AsyncTyper()
+app = AsyncTyper(no_args_is_help=True)
 
 
 def load_ssh_pubkey(ssh_pubkey_file: Path) -> str:

--- a/src/aleph_client/commands/message.py
+++ b/src/aleph_client/commands/message.py
@@ -27,7 +27,7 @@ from aleph_client.commands.utils import (
 from aleph_client.utils import AsyncTyper
 from aleph_message.models import AlephMessage, ItemHash, MessageType, ProgramMessage
 
-app = AsyncTyper()
+app = AsyncTyper(no_args_is_help=True)
 
 
 @app.command()

--- a/src/aleph_client/commands/node.py
+++ b/src/aleph_client/commands/node.py
@@ -16,7 +16,7 @@ from aleph_client.commands.utils import setup_logging
 from aleph_client.utils import AsyncTyper
 
 logger = logging.getLogger(__name__)
-app = AsyncTyper()
+app = AsyncTyper(no_args_is_help=True)
 
 node_link = "https://api2.aleph.im/api/v0/aggregates/0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10.json?keys=corechannel"
 

--- a/src/aleph_client/commands/program.py
+++ b/src/aleph_client/commands/program.py
@@ -30,7 +30,7 @@ from aleph_message.models import (
 from aleph_message.status import MessageStatus
 
 logger = logging.getLogger(__name__)
-app = AsyncTyper()
+app = AsyncTyper(no_args_is_help=True)
 
 
 @app.command()


### PR DESCRIPTION
Problem: Calling a command with no argument only displayed "Press --help for help".

Solution: Use a feature of Typer to display the help automatically when no argument is passed.
