### PR TITLE
Fix: Default instance hypervisor becomes Qemu

### DIFF
--- a/src/aleph_client/conf.py
+++ b/src/aleph_client/conf.py
@@ -40,7 +40,7 @@ class Settings(BaseSettings):
     )
     DEFAULT_ROOTFS_SIZE: int = 20_000
     DEFAULT_INSTANCE_MEMORY: int = 2_048
-    DEFAULT_HYPERVISOR: HypervisorType = HypervisorType.firecracker
+    DEFAULT_HYPERVISOR: HypervisorType = HypervisorType.qemu
 
     DEFAULT_VM_MEMORY: int = 128
     DEFAULT_VM_VCPUS: int = 1


### PR DESCRIPTION
Firecracker does not allow easy snapshotting using Qcow2 or GPU via PCI, so it was decided to switch instances to Qemu.
