### PR TITLE
Fix: Unable to Create PAYG Instance from CLI

### DIFF
--- a/src/aleph_client/commands/aggregate.py
+++ b/src/aleph_client/commands/aggregate.py
@@ -11,7 +11,7 @@ from aleph.sdk.conf import settings as sdk_settings
 from aleph.sdk.query.filters import MessageFilter
 from aleph.sdk.types import AccountFromPrivateKey
 from aleph.sdk.utils import extended_json_encoder
-from aleph_message.models import MessageType
+from aleph_message.models.base import MessageType
 
 from aleph_client.commands import help_strings
 from aleph_client.commands.utils import setup_logging

--- a/src/aleph_client/commands/domain.py
+++ b/src/aleph_client/commands/domain.py
@@ -18,7 +18,8 @@ from aleph.sdk.domain import (
 from aleph.sdk.exceptions import DomainConfigurationError
 from aleph.sdk.query.filters import MessageFilter
 from aleph.sdk.types import AccountFromPrivateKey
-from aleph_message.models import AggregateMessage, MessageType
+from aleph_message.models import AggregateMessage
+from aleph_message.models.base import MessageType
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
 from rich.table import Table
@@ -86,7 +87,7 @@ async def attach_resource(
     resource_type = await get_target_type(fqdn)
 
     if resource_type == TargetType.IPFS and not catch_all_path:
-        catch_all_path = Prompt.ask("Catch all path? ex: /404.html or press [Enter] to ignore", default=None) or None
+        catch_all_path = Prompt.ask("Catch all path? ex: /404.html or press [Enter] to ignore", default=None)
 
     if domain_info is not None and domain_info.get("info"):
         current_resource = domain_info["info"]["message_id"]
@@ -119,6 +120,9 @@ async def attach_resource(
                     "options": options,
                 }
             }
+
+            if catch_all_path and catch_all_path.startswith("/"):
+                aggregate_content[fqdn]["options"] = {"catch_all_path": catch_all_path}
 
             aggregate_message, message_status = await client.create_aggregate(
                 key="domains", content=aggregate_content, channel="ALEPH-CLOUDSOLUTIONS"

--- a/src/aleph_client/commands/instance/display.py
+++ b/src/aleph_client/commands/instance/display.py
@@ -1,0 +1,170 @@
+import asyncio
+from functools import partial
+from typing import Callable, Literal, Set, Sized, Tuple, Union, cast
+
+from rich.console import Console
+from rich.live import Live
+from rich.progress import Progress
+from rich.table import Table
+
+from aleph_client.commands.instance.network import (
+    MachineInfoQueue,
+    fetch_and_queue_crn_info,
+)
+from aleph_client.commands.node import NodeInfo, _fetch_nodes, _format_score
+from aleph_client.models import MachineInfo
+
+
+class ProgressTable:
+    """Display a progress bar and a table side by side."""
+
+    progress: Progress
+    table: Table
+
+    def __init__(self, progress, table):
+        self.progress = progress
+        self.table = table
+
+    def __rich_console__(self, console: Console, options):
+        yield self.progress
+        yield self.table
+
+
+def create_crn_resource_table() -> Table:
+    """Prepare a table to display available resources on CRNs in order to schedule a PAYG instance on it."""
+    table = Table(title="Compute Node Information")
+    table.add_column("Score", style="green", no_wrap=True, justify="center")
+    table.add_column("Name", style="#029AFF", justify="left")
+    table.add_column("Cores", style="green", justify="left")
+    table.add_column("RAM", style="green", justify="left")
+    table.add_column("HDD", style="green", justify="left")
+    table.add_column("Version", style="green", justify="center")
+    table.add_column("Reward Address", style="green", justify="center")
+    table.add_column("Address", style="green", justify="center")
+    return table
+
+
+def create_progress_bar(sized_object: Sized) -> Tuple[Progress, Callable[[], None]]:
+    """Create a progress bar and a function to increment it.
+
+    Args:
+        sized_object: Sized object to create a progress bar for, typically a list.
+    Returns:
+        The progress bar and a function to increment it.
+    """
+    progress_bar = Progress()
+    progress_bar_task = progress_bar.add_task(
+        "[green]Fetching node info... It might take some time",
+        total=len(sized_object),
+    )
+    # We use a partial function to create a function that increments the progress bar by 1
+    # and can be called from within coroutines.
+    increment_progress_bar: Callable[[], None] = partial(progress_bar.update, progress_bar_task, advance=1)
+    return progress_bar, increment_progress_bar
+
+
+def create_table_with_progress_bar(
+    sized_object: Sized,
+) -> Tuple[ProgressTable, Callable[[], None]]:
+    """Create a table of CRNs together with a progress bar and a function to increment it.
+
+    Args:
+        sized_object: Sized object to create a progress bar for, typically a list.
+    Returns:
+        The table and the function to increment the progress bar.
+    """
+    progress_bar, increment_progress_bar = create_progress_bar(sized_object)
+    table = create_crn_resource_table()
+    return ProgressTable(progress_bar, table), increment_progress_bar
+
+
+async def update_table(
+    queue: MachineInfoQueue,
+    table: Table,
+    increment_progress_bar: Callable[[], None],
+    valid_reward_addresses: Set[str],
+) -> None:
+    """
+    Updates table with MachineInfo objects from the queue, updates progress bar and valid reward addresses.
+
+    Args:
+        queue: Asyncio queue that provides MachineInfo objects.
+        table: Rich Table object of CRN resources.
+        increment_progress_bar: Function to increment progress bar.
+        valid_reward_addresses: Set of valid reward addresses to update.
+    """
+    while True:
+        data: Union[MachineInfo, None, Literal["END_OF_QUEUE"]] = await queue.get()
+        increment_progress_bar()
+        if data is None:
+            continue
+        elif data == "END_OF_QUEUE":
+            break
+        else:
+            data = cast(MachineInfo, data)
+            cpu, hdd, ram = convert_system_info_to_str(data)
+            table.add_row(
+                _format_score(data.score),
+                data.name,
+                cpu,
+                ram,
+                hdd,
+                data.version,
+                data.reward_address,
+                data.url,
+            )
+            valid_reward_addresses.add(data.reward_address)
+
+
+def convert_system_info_to_str(data: MachineInfo) -> Tuple[str, str, str]:
+    """
+    Converts MachineInfo object that contains CPU, RAM and HDD information to a tuple of strings.
+
+    Args:
+        data: Information obtained about the CRN.
+
+    Returns:
+        CPU, RAM, and HDD information as strings.
+    """
+    cpu: str = f"{data.machine_usage.cpu.count}"
+    hdd: str = f"{data.machine_usage.disk.available_kB / 1_000_000:.2f} GB"
+    ram: str = f"{data.machine_usage.mem.available_kB / 1_000_000:.2f} GB"
+
+    return cpu, hdd, ram
+
+
+async def fetch_crn_info() -> set:
+    """
+    Fetches compute node information asynchronously.
+    Display and update a Live tab where CRN info will be displayed
+
+    Returns:
+        List of valid reward addresses.
+    """
+
+    # Fetch node information from the API
+    node_info: NodeInfo = await _fetch_nodes()
+
+    # Create the console and progress table
+    console = Console()
+    progress_table, increment_progress_bar = create_table_with_progress_bar(node_info.nodes)
+    valid_reward_addresses: Set[str] = set()
+
+    # We use a queue in order to store retrieved data from the nodes not in order
+    queue: MachineInfoQueue = asyncio.Queue()
+
+    # The Live context manager allows us to update the table and progress bar in real time
+    with Live(progress_table, console=console, refresh_per_second=2):
+        await asyncio.gather(
+            # Fetch CRN info from the nodes into the queue
+            fetch_and_queue_crn_info(node_info, queue),
+            # Update the table with the CRN info from the queue in parallel
+            update_table(
+                queue,
+                progress_table.table,
+                increment_progress_bar,
+                valid_reward_addresses,
+            ),
+        )
+
+    return valid_reward_addresses

--- a/src/aleph_client/commands/instance/display.py
+++ b/src/aleph_client/commands/instance/display.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import asyncio
+import typing
 from functools import partial
 from typing import Callable, Literal, Set, Sized, Tuple, Union, cast
 
@@ -7,12 +10,12 @@ from rich.live import Live
 from rich.progress import Progress
 from rich.table import Table
 
-from aleph_client.commands.instance.network import (
-    MachineInfoQueue,
-    fetch_and_queue_crn_info,
-)
+from aleph_client.commands.instance.network import fetch_and_queue_crn_info
 from aleph_client.commands.node import NodeInfo, _fetch_nodes, _format_score
 from aleph_client.models import MachineInfo
+
+if typing.TYPE_CHECKING:
+    from aleph_client.commands.instance.network import MachineInfoQueue
 
 
 class ProgressTable:

--- a/src/aleph_client/commands/instance/network.py
+++ b/src/aleph_client/commands/instance/network.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import re
+import typing
 from json import JSONDecodeError
 from typing import List, Literal, Optional, Tuple, Union
 from urllib.parse import ParseResult, urlparse
@@ -31,10 +34,12 @@ FORBIDDEN_HOSTS = [
     "youtube.com",
 ]
 
-# A queue is used to pass the machine info from the coroutines that fetch it to the
-# coroutine in charge of updating the table and progress bar.
-# Invalid URLs are represented as None, and the end of the queue is marked with "END_OF_QUEUE".
-MachineInfoQueue = asyncio.Queue[Union[MachineInfo, None, Literal["END_OF_QUEUE"]]]
+# This type annotation is hidden behind typing.TYPE_CHECKING for compatibility with Python 3.8
+if typing.TYPE_CHECKING:
+    # A queue is used to pass the machine info from the coroutines that fetch it to the
+    # coroutine in charge of updating the table and progress bar.
+    # Invalid URLs are represented as None, and the end of the queue is marked with "END_OF_QUEUE".
+    MachineInfoQueue = asyncio.Queue[Union[MachineInfo, None, Literal["END_OF_QUEUE"]]]
 
 
 def get_version(headers: CIMultiDictProxy[str]) -> Optional[str]:

--- a/src/aleph_client/commands/instance/network.py
+++ b/src/aleph_client/commands/instance/network.py
@@ -1,0 +1,169 @@
+import asyncio
+import logging
+import re
+from json import JSONDecodeError
+from typing import List, Literal, Optional, Tuple, Union
+from urllib.parse import ParseResult, urlparse
+
+import aiohttp
+from aiohttp import InvalidURL
+from multidict import CIMultiDictProxy
+from pydantic import ValidationError
+
+from aleph_client.commands.node import NodeInfo
+from aleph_client.conf import settings
+from aleph_client.models import MachineInfo, MachineUsage
+
+logger = logging.getLogger(__name__)
+
+# Some users had fun adding URLs that are obviously not CRNs.
+# If you work for one of these companies, please send a large check to the Aleph team,
+# and we may consider removing your domain from the blacklist. Or just use a subdomain.
+FORBIDDEN_HOSTS = [
+    "amazon.com",
+    "apple.com",
+    "facebook.com",
+    "google.com",
+    "google.es",
+    "microsoft.com",
+    "openai.com",
+    "twitter.com",
+    "youtube.com",
+]
+
+# A queue is used to pass the machine info from the coroutines that fetch it to the
+# coroutine in charge of updating the table and progress bar.
+# Invalid URLs are represented as None, and the end of the queue is marked with "END_OF_QUEUE".
+MachineInfoQueue = asyncio.Queue[Union[MachineInfo, None, Literal["END_OF_QUEUE"]]]
+
+
+def get_version(headers: CIMultiDictProxy[str]) -> Optional[str]:
+    """Extracts the version of the CRN from the headers of the response.
+
+    Args:
+        headers: aiohttp response headers.
+    Returns:
+        Version of the CRN if found, None otherwise.
+    """
+    if "Server" in headers:
+        for server in headers.getall("Server"):
+            version_match: List[str] = re.findall(r"^aleph-vm/(.*)$", server)
+            # Return the first match
+            if version_match and version_match[0]:
+                return version_match[0]
+    return None
+
+
+async def fetch_crn_info(node_url: str) -> Tuple[Optional[MachineUsage], Optional[str]]:
+    """
+    Fetches compute node usage information and version.
+
+    Args:
+        node_url: URL of the compute node.
+    Returns:
+        Machine usage information and version.
+    """
+    # Remove trailing slashes to avoid having // in the URL.
+    url: str = node_url.rstrip("/") + "/about/usage/system"
+    timeout = aiohttp.ClientTimeout(total=settings.HTTP_REQUEST_TIMEOUT)
+    try:
+        # A new session is created for each request since they each target a different host.
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url) as resp:
+                resp.raise_for_status()
+                data_raw: dict = await resp.json()
+                version = get_version(resp.headers)
+                return MachineUsage.parse_obj(data_raw), version
+    except TimeoutError:
+        logger.debug(f"Timeout while fetching: {url}")
+    except aiohttp.ClientConnectionError as e:
+        logger.debug(f"Error on connection: {url}, {e}")
+    except aiohttp.ClientResponseError:
+        logger.debug(f"Error on response: {url}")
+    except JSONDecodeError:
+        logger.debug(f"Error decoding JSON: {url}")
+    except ValidationError as e:
+        logger.debug(f"Validation error when fetching: {url}: {e}")
+    except InvalidURL as e:
+        logger.debug(f"Invalid URL: {url}: {e}")
+    return None, None
+
+
+def sanitize_url(url: str) -> str:
+    """Ensure that the URL is valid and not obviously irrelevant.
+
+    Args:
+        url: URL to sanitize.
+    Returns:
+        Sanitized URL.
+    """
+    if not url:
+        raise InvalidURL("Empty URL")
+
+    # Use urllib3 to parse the URL.
+    # This should raise the same InvalidURL exception if the URL is invalid.
+    parsed_url: ParseResult = urlparse(url)
+
+    if parsed_url.scheme not in ["http", "https"]:
+        raise InvalidURL(f"Invalid URL scheme: {parsed_url.scheme}")
+
+    if parsed_url.hostname in FORBIDDEN_HOSTS:
+        raise InvalidURL("Invalid URL host")
+    return url
+
+
+async def fetch_crn_info_in_queue(node: dict, queue: MachineInfoQueue) -> None:
+    """Fetch the resource usage from a CRN and put it in the queue
+
+    Args:
+        node: Information about the CRN from the 'corechannel' aggregate.
+        queue: Queue used to update the table live.
+    """
+    # Skip nodes without an address or with an invalid address
+    try:
+        node_url = sanitize_url(node["address"])
+    except InvalidURL:
+        logger.info(f"Invalid URL: {node['address']}")
+        await queue.put(None)
+        return
+
+    # Skip nodes without a reward address
+    if not node["stream_reward"]:
+        await queue.put(None)
+        return
+
+    # Fetch the machine usage and version from its HTTP API
+    machine_usage, version = await fetch_crn_info(node_url)
+
+    if not machine_usage:
+        await queue.put(None)
+        return
+
+    await queue.put(
+        MachineInfo.from_unsanitized_input(
+            machine_usage=machine_usage,
+            score=node["score"],
+            name=node["name"],
+            version=version,
+            reward_address=node["stream_reward"],
+            url=node["address"],
+        )
+    )
+
+
+async def fetch_and_queue_crn_info(
+    node_info: NodeInfo,
+    queue: MachineInfoQueue,
+):
+    """Fetch the resource usage of all CRNs in the node_info asynchronously
+    and put them in the queue.
+
+    Fetches the resource usage and version of each node in parallel using a separate coroutine.
+
+    Args:
+        node_info: Information about all CRNs from the 'corechannel' aggregate.
+        queue: Queue used to update the table live.
+    """
+    coroutines = [fetch_crn_info_in_queue(node, queue) for node in node_info.nodes]
+    await asyncio.gather(*coroutines)
+    await queue.put("END_OF_QUEUE")

--- a/src/aleph_client/commands/message.py
+++ b/src/aleph_client/commands/message.py
@@ -18,7 +18,9 @@ from aleph.sdk.query.filters import MessageFilter
 from aleph.sdk.query.responses import MessagesResponse
 from aleph.sdk.types import AccountFromPrivateKey, StorageEnum
 from aleph.sdk.utils import extended_json_encoder
-from aleph_message.models import AlephMessage, ItemHash, MessageType, ProgramMessage
+from aleph_message.models import AlephMessage, ProgramMessage
+from aleph_message.models.base import MessageType
+from aleph_message.models.item_hash import ItemHash
 
 from aleph_client.commands import help_strings
 from aleph_client.commands.utils import (

--- a/src/aleph_client/commands/node.py
+++ b/src/aleph_client/commands/node.py
@@ -55,7 +55,7 @@ def _remove_ansi_escape(string: str) -> str:
     return ansi_escape.sub("", string)
 
 
-def _format_score(score):
+def _format_score(score: float):
     if score < 0.5:
         return text.Text(f"{score:.2%}", style="red", justify="right")
     elif score < 0.75:
@@ -77,25 +77,27 @@ def _show_compute(node_info):
     table.add_column("Creation Time", style="#029AFF", justify="center")
     table.add_column("Decentralization", style="green", justify="right")
     table.add_column("Status", style="green", justify="right")
+    table.add_column("Item Hash", style="green", justify="center")
 
     for node in node_info.nodes:
         # Prevent escaping with name
         node_name = node["name"]
         node_name = _escape_and_normalize(node_name)
         node_name = _remove_ansi_escape(node_name)
-
+        node_hash = node["hash"]
+        node_reward = node["stream_reward"]
         #  Format Value
         creation_time = datetime.datetime.fromtimestamp(node["time"]).strftime("%Y-%m-%d %H:%M:%S")
         score = _format_score(node["score"])
         decentralization = _format_score(node["decentralization"])
         status = _format_status(node["status"])
-
         table.add_row(
             score,
             node_name,
             creation_time,
             decentralization,
             status,
+            node_hash,
         )
 
     console = Console()

--- a/src/aleph_client/commands/program.py
+++ b/src/aleph_client/commands/program.py
@@ -4,23 +4,17 @@ import json
 import logging
 from base64 import b16decode, b32encode
 from pathlib import Path
-from typing import List, Mapping, Optional, cast
+from typing import List, Mapping, Optional
 from zipfile import BadZipFile
 
 import typer
 from aleph.sdk import AuthenticatedAlephHttpClient
 from aleph.sdk.account import _load_account
 from aleph.sdk.conf import settings as sdk_settings
-from aleph.sdk.query.filters import MessageFilter
-from aleph.sdk.query.responses import MessagesResponse
 from aleph.sdk.types import AccountFromPrivateKey, StorageEnum
-from aleph_message.models import (
-    ItemHash,
-    MessageType,
-    ProgramContent,
-    ProgramMessage,
-    StoreMessage,
-)
+from aleph_message.models import ProgramMessage, StoreMessage
+from aleph_message.models.execution.program import ProgramContent
+from aleph_message.models.item_hash import ItemHash
 from aleph_message.status import MessageStatus
 
 from aleph_client.commands import help_strings
@@ -232,10 +226,7 @@ async def unpersist(
     account = _load_account(private_key, private_key_file)
 
     async with AuthenticatedAlephHttpClient(account=account, api_server=sdk_settings.API_HOST) as client:
-        existing: MessagesResponse = await client.get_messages(
-            message_filter=MessageFilter(hashes=[item_hash], message_types=[MessageType.program]),
-        )
-        message: ProgramMessage = cast(ProgramMessage, existing.messages[0])
+        message: ProgramMessage = await client.get_message(item_hash=item_hash, message_type=ProgramMessage)
         content: ProgramContent = message.content.copy()
 
         content.on.persistent = False

--- a/src/aleph_client/commands/utils.py
+++ b/src/aleph_client/commands/utils.py
@@ -14,6 +14,8 @@ from pygments.lexers import JsonLexer
 from rich.prompt import IntPrompt, Prompt, PromptError
 from typer import echo
 
+logger = logging.getLogger(__name__)
+
 
 def colorful_json(obj: str):
     """Render a JSON string with colors."""

--- a/src/aleph_client/conf.py
+++ b/src/aleph_client/conf.py
@@ -32,7 +32,7 @@ class Settings(BaseSettings):
     UBUNTU_22_ROOTFS_ID: str = "77fef271aa6ff9825efa3186ca2e715d19e7108279b817201c69c34cedc74c27"
     DEFAULT_ROOTFS_SIZE: int = 20_000
     DEFAULT_INSTANCE_MEMORY: int = 2_048
-    DEFAULT_HYPERVISOR: HypervisorType = HypervisorType.firecracker
+    DEFAULT_HYPERVISOR: HypervisorType = HypervisorType.qemu
 
     DEFAULT_VM_MEMORY: int = 128
     DEFAULT_VM_VCPUS: int = 1
@@ -47,6 +47,8 @@ class Settings(BaseSettings):
         env_prefix = "ALEPH_"
         case_sensitive = False
         env_file = ".env"
+
+    HTTP_REQUEST_TIMEOUT = 5.0
 
 
 # Settings singleton

--- a/src/aleph_client/models.py
+++ b/src/aleph_client/models.py
@@ -1,0 +1,93 @@
+from datetime import datetime
+from typing import Optional
+
+from aleph_message.models.execution.environment import CpuProperties
+from pydantic import BaseModel
+
+from aleph_client.commands.node import _escape_and_normalize, _remove_ansi_escape
+
+# This is a copy from aleph-vm
+
+
+class LoadAverage(BaseModel):
+    load1: float
+    load5: float
+    load15: float
+
+
+class CoreFrequencies(BaseModel):
+    min: float
+    max: float
+
+
+class CpuUsage(BaseModel):
+    count: int
+    load_average: LoadAverage
+    core_frequencies: CoreFrequencies
+
+
+class MemoryUsage(BaseModel):
+    total_kB: int
+    available_kB: int
+
+
+class DiskUsage(BaseModel):
+    total_kB: int
+    available_kB: int
+
+
+class UsagePeriod(BaseModel):
+    start_timestamp: datetime
+    duration_seconds: float
+
+
+class MachineProperties(BaseModel):
+    cpu: CpuProperties
+
+
+class MachineUsage(BaseModel):
+    cpu: CpuUsage
+    mem: MemoryUsage
+    disk: DiskUsage
+    period: UsagePeriod
+    properties: MachineProperties
+    active: bool = True
+
+
+class MachineInfo(BaseModel):
+    machine_usage: MachineUsage
+    score: float
+    name: str
+    version: Optional[str]
+    reward_address: str
+    url: str
+
+    @classmethod
+    def from_unsanitized_input(cls, machine_usage, score, name, version, reward_address, url):
+        """Create a MachineInfo instance from unsanitized input.
+
+        User input from the account page or the API may contain malicious or unexpected data.
+        This method ensures that the input is sanitized before creating a MachineInfo object.
+
+        Args:
+            machine_usage: MachineUsage object from the CRN API.
+            score: Score of the CRN.
+            name: Name of the CRN.
+            version: Version of the CRN.
+            reward_address: Reward address of the CRN.
+            url: URL of the CRN.
+        """
+        node_name: str = _remove_ansi_escape(_escape_and_normalize(name))
+
+        # The version field is optional, so we need to handle it separately
+        raw_version: Optional[str] = version
+        version = _remove_ansi_escape(_escape_and_normalize(raw_version)) if raw_version else None
+
+        return cls(
+            machine_usage=MachineUsage.parse_obj(machine_usage),
+            score=score,
+            name=node_name,
+            version=version,
+            reward_address=reward_address,
+            url=url,
+        )

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -1,0 +1,180 @@
+import asyncio
+from datetime import datetime, timezone
+from typing import Set
+from unittest import mock
+
+import pytest
+from aiohttp import InvalidURL
+from aleph_message.models.execution.environment import CpuProperties
+from multidict import CIMultiDict, CIMultiDictProxy
+
+from aleph_client.commands.instance.display import (
+    ProgressTable,
+    create_table_with_progress_bar,
+    update_table,
+)
+from aleph_client.commands.instance.network import (
+    FORBIDDEN_HOSTS,
+    MachineInfoQueue,
+    fetch_crn_info,
+    get_version,
+    sanitize_url,
+)
+from aleph_client.models import (
+    CoreFrequencies,
+    CpuUsage,
+    DiskUsage,
+    LoadAverage,
+    MachineInfo,
+    MachineProperties,
+    MachineUsage,
+    MemoryUsage,
+    UsagePeriod,
+)
+
+
+def dummy_machine_info() -> MachineInfo:
+    """Create a dummy MachineInfo object for testing purposes."""
+    return MachineInfo(
+        machine_usage=MachineUsage(
+            cpu=CpuUsage(
+                count=8,
+                load_average=LoadAverage(load1=0.5, load5=0.4, load15=0.3),
+                core_frequencies=CoreFrequencies(min=1.0, max=2.0),
+            ),
+            mem=MemoryUsage(
+                total_kB=1_000_000,
+                available_kB=500_000,
+            ),
+            disk=DiskUsage(
+                total_kB=1_000_000,
+                available_kB=500_000,
+            ),
+            period=UsagePeriod(
+                start_timestamp=datetime.now(tz=timezone.utc),
+                duration_seconds=60,
+            ),
+            properties=MachineProperties(
+                cpu=CpuProperties(
+                    architecture="x86_64",
+                    vendor="AuthenticAMD",
+                ),
+            ),
+        ),
+        score=0.5,
+        name="CRN",
+        version="0.0.1",
+        reward_address="0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
+        url="https://example.com",
+    )
+
+
+def dict_to_ci_multi_dict_proxy(d: dict) -> CIMultiDictProxy:
+    """Return a read-only proxy to a case-insensitive multi-dict created from a dict."""
+    return CIMultiDictProxy(CIMultiDict(d))
+
+
+def test_get_version() -> None:
+
+    # No server field in headers
+    headers = dict_to_ci_multi_dict_proxy({})
+    assert get_version(headers) is None
+
+    # Server header but no aleph-vm
+    headers = dict_to_ci_multi_dict_proxy({"Server": "nginx"})
+    assert get_version(headers) is None
+
+    # Server header with aleph-vm
+    headers = dict_to_ci_multi_dict_proxy({"Server": "aleph-vm/0.1.0"})
+    assert get_version(headers) == "0.1.0"
+
+    # Server header multiple aleph-vm values
+    headers = dict_to_ci_multi_dict_proxy({"Server": "aleph-vm/0.1.0", "server": "aleph-vm/0.2.0"})
+    assert get_version(headers) == "0.1.0"
+
+
+def test_create_table_with_progress_bar():
+    """Test the creation of a table with progress bar."""
+    sized_object = [1, 2, 3]
+    table, increment_function = create_table_with_progress_bar(sized_object)
+    assert isinstance(table, ProgressTable)
+
+    # Test that calling the increment function ends up with the progress bar
+    # being finished after `len(sized_objects)` calls.
+    for i in range(3):
+        # The progress bar should not be finished yet
+        assert table.progress.tasks[0].finished_time is None
+        increment_function()
+
+    # The progress bar should be finished now
+    finished_time = table.progress.tasks[0].finished_time
+    assert finished_time is not None and finished_time > 0
+
+
+@pytest.mark.asyncio
+async def test_update_table():
+    queue: MachineInfoQueue = asyncio.Queue()
+    table = mock.Mock()
+    table.add_row = mock.Mock()
+    increment_progress_bar = mock.Mock()
+    valid_reward_addresses: Set[str] = set()
+
+    async def populate_queue():
+        assert table.add_row.call_count == 0
+        # Put the data in the queue
+        await queue.put(dummy_machine_info())
+        # End the test by putting an end of queue marker
+        await queue.put("END_OF_QUEUE")
+
+    # Populate the queue and update the table concurrently.
+    await asyncio.gather(
+        populate_queue(),
+        update_table(queue, table, increment_progress_bar, valid_reward_addresses),
+    )
+
+    assert table.add_row.call_count == 1
+    assert valid_reward_addresses == {dummy_machine_info().reward_address}
+
+
+@pytest.mark.asyncio
+async def test_fetch_crn_info() -> None:
+    # Test with valid node
+    # TODO: Mock the response from the node, don't rely on a real node
+    node_url = "https://ovh.staging.aleph.sh"
+    machine_usage, version = await fetch_crn_info(node_url)
+    assert machine_usage is not None
+    assert version is not None
+    assert isinstance(machine_usage, MachineUsage)
+    assert isinstance(version, str)
+
+    # Test with invalid node
+    invalid_node_url = "https://coconut.example.org/"
+    assert await fetch_crn_info(invalid_node_url) == (None, None)
+
+    # TODO: Test different error handling
+
+
+def test_sanitize_url_with_empty_url():
+    with pytest.raises(InvalidURL, match="Empty URL"):
+        sanitize_url("")
+
+
+def test_sanitize_url_with_invalid_scheme():
+    with pytest.raises(InvalidURL, match="Invalid URL scheme"):
+        sanitize_url("ftp://example.org")
+
+
+def test_sanitize_url_with_forbidden_host():
+    for host in FORBIDDEN_HOSTS:
+        with pytest.raises(InvalidURL, match="Invalid URL host"):
+            sanitize_url(f"http://{host}")
+
+
+def test_sanitize_url_with_valid_url():
+    url = "http://example.org"
+    assert sanitize_url(url) == url
+
+
+def test_sanitize_url_with_https_scheme():
+    url = "https://example.org"
+    assert sanitize_url(url) == url

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import asyncio
+import typing
 from datetime import datetime, timezone
 from typing import Set
 from unittest import mock
@@ -15,7 +18,6 @@ from aleph_client.commands.instance.display import (
 )
 from aleph_client.commands.instance.network import (
     FORBIDDEN_HOSTS,
-    MachineInfoQueue,
     fetch_crn_info,
     get_version,
     sanitize_url,
@@ -31,6 +33,9 @@ from aleph_client.models import (
     MemoryUsage,
     UsagePeriod,
 )
+
+if typing.TYPE_CHECKING:
+    from aleph_client.commands.instance.network import MachineInfoQueue
 
 
 def dummy_machine_info() -> MachineInfo:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,11 +1,11 @@
 from aleph_message.models import (
     AggregateMessage,
     ForgetMessage,
-    MessageType,
     PostMessage,
     ProgramMessage,
     StoreMessage,
 )
+from aleph_message.models.base import MessageType
 
 from aleph_client.utils import get_message_type_value
 


### PR DESCRIPTION
Issue: Previously, users were unable to create PAYG instances from the CLI using a CRN.

Solution: Implemented a prompt to ask users if they want to create a PAYG instance,
displaying a list of compatible CRNs after an asynchronous fetching of the information.

Co-authored-by: Hugo Herter <git@hugoherter.com>
