### PR TITLE
feat: add x.com to list of forbidden host

### DIFF
--- a/src/aleph_client/commands/instance/network.py
+++ b/src/aleph_client/commands/instance/network.py
@@ -31,6 +31,7 @@ FORBIDDEN_HOSTS = [
     "microsoft.com",
     "openai.com",
     "twitter.com",
+    "x.com",
     "youtube.com",
 ]
 


### PR DESCRIPTION
Twitter's new domain name.