### PR TITLE
Refactor: Allow aleph instance list to handle PAYG

### DIFF
--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -275,8 +275,8 @@ async def _get_ipv6_address(message: InstanceMessage, node_list: NodeInfo) -> Tu
                         return message.item_hash, ipv6_address
 
             return message.item_hash, "Not available (yet)"
-        except ClientResponseError:
-            return message.item_hash, "Not available (yet), server not responding"
+        except ClientResponseError as e:
+            return message.item_hash, f"Not available (yet), server not responding {e}"
 
 
 async def _show_instances(messages: List[InstanceMessage], node_list: NodeInfo):

--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -37,7 +37,7 @@ from aleph_client.commands.utils import (
     validated_prompt,
 )
 from aleph_client.conf import settings
-from aleph_client.utils import AsyncTyper
+from aleph_client.utils import AsyncTyper, fetch_json
 
 logger = logging.getLogger(__name__)
 app = AsyncTyper(no_args_is_help=True)
@@ -255,12 +255,6 @@ async def delete(
         typer.echo(f"Instance {item_hash} has been deleted. It will be removed by the scheduler in a few minutes.")
 
 
-async def fetch_json(session: ClientSession, url: str) -> dict:
-    async with session.get(url) as resp:
-        resp.raise_for_status()
-        return await resp.json()
-
-
 async def _get_ipv6_address(message: InstanceMessage, node_list: NodeInfo) -> Tuple[str, str]:
     async with ClientSession() as session:
         try:
@@ -282,7 +276,7 @@ async def _get_ipv6_address(message: InstanceMessage, node_list: NodeInfo) -> Tu
 
             return message.item_hash, "Not available (yet)"
         except ClientResponseError:
-            return message.item_hash, "Not available (yet)"
+            return message.item_hash, "Not available (yet), server not responding"
 
 
 async def _show_instances(messages: List[InstanceMessage], node_list: NodeInfo):

--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -276,7 +276,7 @@ async def _get_ipv6_address(message: InstanceMessage, node_list: NodeInfo) -> Tu
 
             return message.item_hash, "Not available (yet)"
         except ClientResponseError as e:
-            return message.item_hash, f"Not available (yet), server not responding {e}"
+            return message.item_hash, f"Not available (yet), server not responding : {e}"
 
 
 async def _show_instances(messages: List[InstanceMessage], node_list: NodeInfo):

--- a/src/aleph_client/utils.py
+++ b/src/aleph_client/utils.py
@@ -9,6 +9,7 @@ from typing import Tuple, Type
 from zipfile import BadZipFile, ZipFile
 
 import typer
+from aiohttp import ClientResponseError, ClientSession
 from aleph.sdk.types import GenericMessage
 from aleph_message.models.base import MessageType
 from aleph_message.models.execution.base import Encoding
@@ -16,7 +17,6 @@ from aleph_message.models.execution.base import Encoding
 from aleph_client.conf import settings
 
 logger = logging.getLogger(__name__)
-
 
 try:
     import magic
@@ -85,3 +85,9 @@ class AsyncTyper(typer.Typer):
     def command(self, *args, **kwargs):
         decorator = super().command(*args, **kwargs)
         return partial(self.maybe_run_async, decorator)
+
+
+async def fetch_json(session: ClientSession, url: str) -> dict:
+    async with session.get(url) as resp:
+        resp.raise_for_status()
+        return await resp.json()


### PR DESCRIPTION
Problem:
```aleph instance list``` only handles the Hold method.

Solution:
Check the payment type and fetch api_url and ipv6 from ```/about/executions/list.```

Changes:
- Added logic to check if there is a payment associated with the message.
- If there is no payment, the function fetches the VM details from the scheduler API.
- If there is a payment, the function fetches the server URL and retrieves the ipv6 address from the node's execution list