### PR TITLE
Fix: Ensure consistent URL formatting in _get_ipv6_address

### DIFF
--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -366,8 +366,14 @@ async def _get_ipv6_address(message: InstanceMessage, node_list: NodeInfo) -> Tu
             for node in node_list.nodes:
                 if node["stream_reward"] == message.content.payment.receiver:
 
+                    # Handle both cases where the address might or might not end with a '/'
+                    path: str = (
+                        f"{node['address']}about/executions/list"
+                        if node["address"][-1] == "/"
+                        else f"{node['address']}/about/executions/list"
+                    )
                     # Fetch from the CRN API if payment
-                    executions = await fetch_json(session, f"{node['address']}about/executions/list")
+                    executions = await fetch_json(session, path)
                     if message.item_hash in executions:
                         ipv6_address = executions[message.item_hash]["networking"]["ipv6"]
                         return message.item_hash, ipv6_address


### PR DESCRIPTION
Problem:

In the node_list, the addresses are stored inconsistently. Some nodes have addresses without a trailing slash, like:
``` json
"address": "https://acn-000060.nodeforge.io"
```
While others have addresses with a trailing slash:

``` json
"address": "https://aleph3.serverrg.eu/"
```
Solution:

Ensure consistent URL formatting by appending the path correctly, regardless of whether the address ends with a slash. This will prevent any issues caused by missing or double slashes when constructing URLs. The implementation will check if the last character of the address is a slash and adjust accordingly.