### PR TITLE
Fix: revert upgrade: aiohttp 3.10.2 -> 3.9.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
   "aleph-sdk-python>=1.0.0rc2",
   "aleph-message>=0.4.6",
-  "aiohttp==3.10.2",
+  "aiohttp==3.9.5",
   "typer==0.12.3",
   "python-magic==0.4.27",
   "pygments==2.18.0",


### PR DESCRIPTION
This new merged PR broke aleph-client on Windows: https://github.com/aleph-im/aleph-client/pull/239
The only fix right now seems to be downgrading to 3.9.5, according to https://github.com/nathom/streamrip/issues/729
![image](https://github.com/user-attachments/assets/19fa6102-d191-4a27-bb11-1cc37f6d85d6)