### PR TITLE
Fix: Cross-device links crashed 'confidential-init-session'

### DIFF
--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -602,7 +602,8 @@ async def confidential_init_session(
         echo("Could not get the certificate from the CRN.")
         return
 
-    platform_cert_path = Path(platform_file).rename(session_dir / "platform_certificate.pem")
+    # pathlib.Path.rename raises "Invalid cross-device link" if the destionation is not on the current filesystem.
+    platform_cert_path = shutil.move(platform_file, session_dir / "platform_certificate.pem")
     certificate_prefix = str(session_dir) + "/vm"
 
     # Create local session files

--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -602,7 +602,7 @@ async def confidential_init_session(
         echo("Could not get the certificate from the CRN.")
         return
 
-    # pathlib.Path.rename raises "Invalid cross-device link" if the destionation is not on the current filesystem.
+    # pathlib.Path.rename raises "Invalid cross-device link" if the destination is not on the current filesystem.
     platform_cert_path = shutil.move(platform_file, session_dir / "platform_certificate.pem")
     certificate_prefix = str(session_dir) + "/vm"
 


### PR DESCRIPTION
Solves https://github.com/aleph-im/aleph-client/issues/245

The function attempts to move a file from `/tmp`
to ~/.aleph-im/confidential_sessions .

This crashed if those were on a different
filesystem.

Replacing `pathlib.Path.rename` with `shutil.move` solves this issue as the later can handle this situation.