### PR TITLE
Problem: Creating non coco instance resulted in invalud message

### DIFF
--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -283,7 +283,9 @@ async def create(
                 hypervisor=hypervisor,
                 payment=payment,
                 requirements=HostRequirements(node=NodeRequirements(node_hash=crn.hash)) if crn else None,
-                trusted_execution=TrustedExecutionEnvironment(firmware=confidential_firmware_as_hash),
+                trusted_execution=(
+                    TrustedExecutionEnvironment(firmware=confidential_firmware_as_hash) if confidential else None
+                ),
             )
         except InsufficientFundsError as e:
             typer.echo(


### PR DESCRIPTION
Regular instance shouldn't have the trusted_execution field set per spec

Solution: Set field to zero depending of confidential flag

Explain what problem this PR is resolving

Related ClickUp, GitHub or Jira tickets : ALEPH-XXX

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [] All new code is covered by relevant tests.
- [x] Documentation has been updated regarding these changes.

## Changes
 Set field to zero depending of confidential flag

## How to test

Use `aleph instance create` to create a non confidential instance and check it is created

## Print screen / video

N/A
