### PR TITLE
Confidential command: Pass hash vm_id and crn_url as argument

### DIFF
--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -916,9 +916,9 @@ async def confidential_start(
 
 @app.command()
 async def confidential(
-    crn_url: Optional[str] = typer.Option(None, help=help_strings.CRN_URL),
-    crn_hash: Optional[str] = typer.Option(None, help=help_strings.CRN_HASH),
-    vm_id: Optional[str] = typer.Option(None, help=help_strings.VM_ID),
+    vm_id: Optional[str] = typer.Argument(default=None, help=help_strings.VM_ID),
+    crn_url: Optional[str] = typer.Argument(default=None, help=help_strings.CRN_URL),
+    crn_hash: Optional[str] = typer.Option(default=None, help=help_strings.CRN_HASH),
     policy: int = typer.Option(default=0x1),
     confidential_firmware: str = typer.Option(
         default=settings.DEFAULT_CONFIDENTIAL_FIRMWARE, help=help_strings.CONFIDENTIAL_FIRMWARE


### PR DESCRIPTION
Instead of as option using --vm-id and --crn-url
This allow staying conistant with the other instance command targeting a VM


## Self proofreading checklist

- [x ] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.


## How to test

`aleph instance confidential <vm_id> <crn_url>`
and 
`aleph instance confidential`