### PR TITLE
Fix CRNtable, sort_by keys, autofiltering on reward_add/qemu/coco

### DIFF
--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -135,10 +135,10 @@ async def create(
 
     if confidential:
         if hypervisor and hypervisor != HypervisorType.qemu:
-            echo(f"Only QEMU is supported as an hypervisor for confidential")
+            echo("Only QEMU is supported as an hypervisor for confidential")
             raise typer.Exit(code=1)
         elif not hypervisor:
-            echo(f"Using QEMU as hypervisor for confidential")
+            echo("Using QEMU as hypervisor for confidential")
             hypervisor = HypervisorType.qemu
 
     available_hypervisors = {
@@ -393,7 +393,7 @@ async def create(
         else:
             console.print(
                 f"Your instance {item_hash_text} is registered to be deployed on aleph.im.",
-                f"\nThe scheduler usually takes a few minutes to set it up and start it.",
+                "\nThe scheduler usually takes a few minutes to set it up and start it.",
             )
             if verbose:
                 console.print(
@@ -447,7 +447,7 @@ async def delete(
                 status = await erase(item_hash, crn_url, private_key, private_key_file, True, debug)
                 if status == 1:
                     echo(f"No associated VM on {crn_url}. Skipping...")
-            except Exception as e:
+            except Exception:
                 echo(f"Failed to erase associated VM on {crn_url}. Skipping...")
         else:
             echo(f"Instance {item_hash} was auto-scheduled, VM will be erased automatically.")
@@ -483,7 +483,7 @@ async def _get_instance_details(message: InstanceMessage, node_list: NodeInfo) -
                     )
                     nodes = await fetch_json(
                         session,
-                        f"https://scheduler.api.aleph.cloud/api/v0/nodes",
+                        "https://scheduler.api.aleph.cloud/api/v0/nodes",
                     )
                     details["ipv6_logs"] = allocation["vm_ipv6"]
                     for node in nodes["nodes"]:
@@ -930,7 +930,7 @@ async def confidential_start(
     await client.close()
     console = Console()
     console.print(
-        "Your instance is currently starting..." "\n\nLogs can be fetched using:\n\n",
+        "Your instance is currently starting...\n\nLogs can be fetched using:\n\n",
         Text.assemble(
             "  aleph instance logs ",
             Text(vm_id, style="bright_cyan"),

--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -248,7 +248,7 @@ async def create(
             if crn_info:
                 crn = CRNInfo(
                     hash=ItemHash(crn_hash),
-                    name=name,
+                    name=name or "?",
                     url=crn_url,
                     version=crn_info.get("version", ""),
                     score=score,

--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -430,7 +430,7 @@ async def _get_instance_details(message: InstanceMessage, node_list: NodeInfo) -
     async with ClientSession() as session:
         hold = not message.content.payment or message.content.payment.type == PaymentType["hold"]
         confidential = (
-            has_nested_attr(message.content, ["environment", "trusted_execution", "firmware"])
+            has_nested_attr(message.content, "environment", "trusted_execution", "firmware")
             and len(getattr(message.content.environment.trusted_execution, "firmware")) == 64
         )
         details = dict(
@@ -466,10 +466,10 @@ async def _get_instance_details(message: InstanceMessage, node_list: NodeInfo) -
                 details["allocation_type"] = help_strings.ALLOCATION_MANUAL
                 for node in node_list.nodes:
                     if (
-                        has_nested_attr(message.content, ["payment", "receiver"])
+                        has_nested_attr(message.content, "payment", "receiver")
                         and node["stream_reward"] == getattr(message.content.payment, "receiver")
                     ) or (
-                        has_nested_attr(message.content, ["requirements", "node", "node_hash"])
+                        has_nested_attr(message.content, "requirements", "node", "node_hash")
                         and message.content.requirements is not None
                         and node["hash"] == getattr(message.content.requirements.node, "node_hash")
                     ):
@@ -531,7 +531,7 @@ async def _show_instances(messages: List[InstanceMessage], node_list: NodeInfo):
             f"vCPUs: {message.content.resources.vcpus}\n"
             f"RAM: {message.content.resources.memory / 1_024:.2f} GiB\n"
             f"Disk: {message.content.rootfs.size_mib / 1_024:.2f} GiB\n"
-            f"HyperV: {message.content.environment.hypervisor if has_nested_attr(message.content, ['environment', 'hypervisor']) else 'firecracker'}\n"
+            f"HyperV: {message.content.environment.hypervisor if has_nested_attr(message.content, 'environment', 'hypervisor') else 'firecracker'}\n"
         )
         status_column = Text.assemble(
             Text.assemble(

--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -78,7 +78,7 @@ async def create(
     ),
     crn_hash: Optional[str] = typer.Option(None, help=help_strings.CRN_HASH),
     crn_url: Optional[str] = typer.Option(None, help=help_strings.CRN_URL),
-    confidential: Optional[bool] = typer.Option(None, help=help_strings.CONFIDENTIAL_OPTION),
+    confidential: bool = typer.Option(False, help=help_strings.CONFIDENTIAL_OPTION),
     confidential_firmware: str = typer.Option(
         default=settings.DEFAULT_CONFIDENTIAL_FIRMWARE, help=help_strings.CONFIDENTIAL_FIRMWARE
     ),
@@ -187,7 +187,7 @@ async def create(
     async with AlephHttpClient(api_server=sdk_settings.API_HOST) as client:
         rootfs_message: StoreMessage = await client.get_message(item_hash=rootfs, message_type=StoreMessage)
         if not rootfs_message:
-            typer.echo("Given rootfs volume does not exist on aleph.im")
+            echo("Given rootfs volume does not exist on aleph.im")
             raise typer.Exit(code=1)
         if rootfs_size is None and rootfs_message.content.size:
             rootfs_size = rootfs_message.content.size
@@ -201,7 +201,7 @@ async def create(
                 item_hash=confidential_firmware, message_type=StoreMessage
             )
             if not firmware_message:
-                typer.echo("Confidential Firmware hash does not exist on aleph.im")
+                echo("Confidential Firmware hash does not exist on aleph.im")
                 raise typer.Exit(code=1)
     name = name or validated_prompt("Instance name", lambda x: len(x) < 65)
     rootfs_size = rootfs_size or validated_int_prompt(
@@ -289,13 +289,13 @@ async def create(
                 ),
             )
         except InsufficientFundsError as e:
-            typer.echo(
+            echo(
                 f"Instance creation failed due to insufficient funds.\n"
                 f"{account.get_address()} on {account.CHAIN} has {e.available_funds} ALEPH but needs {e.required_funds} ALEPH."
             )
             raise typer.Exit(code=1)
         if print_messages:
-            typer.echo(f"{message.json(indent=4)}")
+            echo(f"{message.json(indent=4)}")
 
         item_hash: ItemHash = message.item_hash
         item_hash_text = Text(item_hash, style="bright_cyan")
@@ -314,7 +314,6 @@ async def create(
                 status, result = await crn_client.start_instance(vm_id=item_hash)
                 logger.debug(status, result)
                 if int(status) != 200:
-                    print(status, result)
                     echo(f"Could not start instance {item_hash} on CRN.")
                     return item_hash, crn_url
             console.print(f"Your instance {item_hash_text} has been deployed on aleph.im.")
@@ -395,14 +394,15 @@ async def delete(
             existing_message: InstanceMessage = await client.get_message(
                 item_hash=ItemHash(item_hash), message_type=InstanceMessage
             )
+
         except MessageNotFoundError:
-            typer.echo("Instance does not exist")
+            echo("Instance does not exist")
             raise typer.Exit(code=1)
         except ForgottenMessageError:
-            typer.echo("Instance already forgotten")
+            echo("Instance already forgotten")
             raise typer.Exit(code=1)
         if existing_message.sender != account.get_address():
-            typer.echo("You are not the owner of this instance")
+            echo("You are not the owner of this instance")
             raise typer.Exit(code=1)
 
         # Check status of the instance and eventually erase associated VM
@@ -414,16 +414,16 @@ async def delete(
             try:
                 status = await erase(item_hash, crn_url, private_key, private_key_file, True, debug)
                 if status == 1:
-                    typer.echo(f"No associated VM on {crn_url}. Skipping...")
+                    echo(f"No associated VM on {crn_url}. Skipping...")
             except Exception as e:
-                typer.echo(f"Failed to erase associated VM on {crn_url}. Skipping...")
+                echo(f"Failed to erase associated VM on {crn_url}. Skipping...")
         else:
-            typer.echo(f"Instance {item_hash} was auto-scheduled, VM will be erased automatically.")
+            echo(f"Instance {item_hash} was auto-scheduled, VM will be erased automatically.")
 
         message, status = await client.forget(hashes=[ItemHash(item_hash)], reason=reason)
         if print_message:
-            typer.echo(f"{message.json(indent=4)}")
-        typer.echo(f"Instance {item_hash} has been deleted.")
+            echo(f"{message.json(indent=4)}")
+        echo(f"Instance {item_hash} has been deleted.")
 
 
 async def _get_instance_details(message: InstanceMessage, node_list: NodeInfo) -> Tuple[str, Dict[str, object]]:
@@ -629,10 +629,10 @@ async def list(
             page_size=100,
         )
         if not resp or len(resp.messages) == 0:
-            typer.echo(f"Address: {address}\n\nNo instance found\n")
+            echo(f"Address: {address}\n\nNo instance found\n")
             raise typer.Exit(code=1)
         if json:
-            typer.echo(resp.json(indent=4))
+            echo(resp.json(indent=4))
         else:
             # Since we filtered on message type, we can safely cast as InstanceMessage.
             messages = cast(List[InstanceMessage], resp.messages)
@@ -656,9 +656,9 @@ async def expire(
     async with VmClient(account, domain) as manager:
         status, result = await manager.expire_instance(vm_id=vm_id)
         if status != 200:
-            typer.echo(f"Status: {status}")
+            echo(f"Status: {status}")
             return 1
-        typer.echo(f"VM expired on CRN: {domain}")
+        echo(f"VM expired on CRN: {domain}")
 
 
 @app.command()
@@ -680,9 +680,9 @@ async def erase(
         status, result = await manager.erase_instance(vm_id=vm_id)
         if status != 200:
             if not silent:
-                typer.echo(f"Status: {status}")
+                echo(f"Status: {status}")
             return 1
-        typer.echo(f"VM erased on CRN: {domain}")
+        echo(f"VM erased on CRN: {domain}")
 
 
 @app.command()
@@ -702,9 +702,9 @@ async def reboot(
     async with VmClient(account, domain) as manager:
         status, result = await manager.reboot_instance(vm_id=vm_id)
         if status != 200:
-            typer.echo(f"Status: {status}")
+            echo(f"Status: {status}")
             return 1
-        typer.echo(f"VM rebooted on CRN: {domain}")
+        echo(f"VM rebooted on CRN: {domain}")
 
 
 @app.command()
@@ -724,9 +724,9 @@ async def allocate(
     async with VmClient(account, domain) as manager:
         status, result = await manager.start_instance(vm_id=vm_id)
         if status != 200:
-            typer.echo(f"Status: {status}")
+            echo(f"Status: {status}")
             return 1
-        typer.echo(f"VM allocated on CRN: {domain}")
+        echo(f"VM allocated on CRN: {domain}")
 
 
 @app.command()
@@ -746,7 +746,7 @@ async def logs(
         async for log in manager.get_logs(vm_id=vm_id):
             log_data = json.loads(log)
             if "message" in log_data:
-                typer.echo(log_data["message"])
+                echo(log_data["message"])
 
 
 @app.command()
@@ -766,9 +766,9 @@ async def stop(
     async with VmClient(account, domain) as manager:
         status, result = await manager.stop_instance(vm_id=vm_id)
         if status != 200:
-            typer.echo(f"Status : {status}")
+            echo(f"Status : {status}")
             return 1
-        typer.echo(f"VM stopped on CRN: {domain}")
+        echo(f"VM stopped on CRN: {domain}")
 
 
 @app.command()

--- a/src/aleph_client/commands/instance/display.py
+++ b/src/aleph_client/commands/instance/display.py
@@ -2,11 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Dict, Optional, Set, Tuple
+from typing import Dict, Optional, Set
 
-from aiohttp import InvalidURL
-from aleph_message.models import ItemHash
-from pydantic import BaseModel
 from textual.app import App
 from textual.containers import Horizontal
 from textual.css.query import NoMatches
@@ -14,194 +11,200 @@ from textual.reactive import reactive
 from textual.widgets import DataTable, Footer, Label, ProgressBar
 from textual.widgets._data_table import RowKey
 
-from aleph_client.commands.instance.network import (
-    fetch_crn_config,
-    fetch_crn_info,
-    sanitize_url,
-)
+from aleph_client.commands.instance.network import fetch_crn_info
 from aleph_client.commands.node import NodeInfo, _fetch_nodes, _format_score
-from aleph_client.models import MachineUsage
+from aleph_client.models import CRNInfo
+from aleph_client.utils import extract_valid_eth_address
 
 logger = logging.getLogger(__name__)
 
 
-def convert_system_info_to_str(data: CRNInfo) -> Tuple[str, str, str]:
-    """
-    Converts MachineInfo object that contains CPU, RAM and HDD information to a tuple of strings.
-
-    Args:
-        data: Information obtained about the CRN.
-
-    Returns:
-        CPU, RAM, and HDD information as strings.
-    """
-    cpu: str = f"{data.machine_usage.cpu.count}" if data.machine_usage else "N/A"
-    hdd: str = f"{data.machine_usage.disk.available_kB / 1_000_000:.0f} GB" if data.machine_usage else "N/A"
-    ram: str = f"{data.machine_usage.mem.available_kB / 1_000_000:.0f} GB" if data.machine_usage else "N/A"
-
-    return cpu, hdd, ram
-
-
-class CRNInfo(BaseModel):
-    machine_usage: Optional[MachineUsage]
-    score: float
-    hash: ItemHash
-    name: str
-    version: Optional[str]
-    stream_reward_address: str
-    url: str
-    confidential_computing: Optional[bool]
-
-
-class DisplayMachineUsage(BaseModel):
-    cpu: str = "N/A"
-    mem: str = "N/A"
-    disk: str = "N/A"
-
-
 class CRNTable(App[CRNInfo]):
-    crns: Dict[RowKey, CRNInfo] = {}
-    tasks: Set[asyncio.Task] = set()
-    text = reactive("Loading CRNs list ")
     table: DataTable
+    tasks: Set[asyncio.Task] = set()
+    crns: Dict[RowKey, CRNInfo] = {}
+    total_crns: int
+    active_crns: int = 0
+    filtered_crns: int = 0
+    label_start = reactive("Loading CRNs list ")
+    label_end = reactive("")
+    only_reward_address: bool = False
+    only_qemu: bool = False
+    only_confidentials: bool = False
+    current_sorts: set = set()
+    BINDINGS = [
+        ("s", "sort_by_score", "Sort By Score"),
+        ("n", "sort_by_name", "Sort By Name"),
+        ("v", "sort_by_version", "Sort By Version"),
+        ("a", "sort_by_address", "Sort By Address"),
+        ("c", "sort_by_confidential", "Sort By 🔒"),
+        ("q", "sort_by_qemu", "Sort By Qemu"),
+        ("u", "sort_by_url", "Sort By URL"),
+        ("x", "quit", "Exit"),
+    ]
+
+    def __init__(self, only_reward_address: bool = False, only_qemu: bool = False, only_confidentials: bool = False):
+        super().__init__()
+        self.only_reward_address = only_reward_address
+        self.only_qemu = only_qemu
+        self.only_confidentials = only_confidentials
 
     def compose(self):
         """Create child widgets for the app."""
         self.table = DataTable(cursor_type="row", name="Select CRN")
         self.table.add_column("Score", key="score")
         self.table.add_column("Name", key="name")
-        self.table.add_column("Reward Address")
-        self.table.add_column("Confidential", key="confidential_computing")
-        self.table.add_column("Cores", key="cpu")
-        self.table.add_column("RAM", key="ram")
-        self.table.add_column("HDD", key="hdd")
         self.table.add_column("Version", key="version")
-        self.table.add_column("URL")
+        self.table.add_column("Reward Address", key="stream_reward_address")
+        self.table.add_column("🔒", key="confidential_computing")
+        self.table.add_column("Qemu", key="qemu_support")
+        self.table.add_column("Cores", key="cpu")
+        self.table.add_column("Free RAM 🌡", key="ram")
+        self.table.add_column("Free Disk 💿", key="hdd")
+        self.table.add_column("URL", key="url")
         yield Label("Choose a Compute Resource Node (CRN) to run your instance")
         with Horizontal():
-            self.loader_label = Label(self.text)
-            yield self.loader_label
-            yield ProgressBar(show_eta=False)
+            self.loader_label_start = Label(self.label_start)
+            yield self.loader_label_start
+            self.progress_bar = ProgressBar(show_eta=False)
+            yield self.progress_bar
+            self.loader_label_end = Label(self.label_end)
+            yield self.loader_label_end
         yield self.table
         yield Footer()
 
     async def on_mount(self):
-
+        self.table.styles.height = "95%"
         task = asyncio.create_task(self.fetch_node_list())
         self.tasks.add(task)
         task.add_done_callback(self.tasks.discard)
 
     async def fetch_node_list(self):
         nodes: NodeInfo = await _fetch_nodes()
-
         for node in nodes.nodes:
-            info = CRNInfo(
+            self.crns[RowKey(node["hash"])] = CRNInfo(
                 hash=node["hash"],
-                score=node["score"],
                 name=node["name"],
-                stream_reward_address=node["stream_reward"],
                 url=node["address"].rstrip("/"),
-                machine_usage=None,
                 version=None,
+                score=node["score"],
+                stream_reward_address=node["stream_reward"],
+                machine_usage=None,
+                qemu_support=None,
                 confidential_computing=None,
             )
-            usage: DisplayMachineUsage = DisplayMachineUsage()
 
-            if isinstance(info.machine_usage, MachineUsage):
-                usage.disk = str(info.machine_usage.disk.available_kB)
-                usage.mem = str(info.machine_usage.mem.available_kB)
-                usage.cpu = str(info.machine_usage.cpu.count)
-
-            self.table.add_row(
-                _format_score(info.score),
-                info.name,
-                info.stream_reward_address,
-                info.confidential_computing,
-                info.version,
-                usage.cpu,
-                usage.mem,
-                usage.disk,
-                info.url,
-                key=info.hash,
-            )
-            self.crns[RowKey(info.hash)] = info
-
-        progress = self.query_one(ProgressBar)
-        progress.total = len(self.crns)
-        # Retrieve more info by contacting each separate CRN in the background
-        self.loader_label.update("Fetching information from each node ")
+        # Initialize the progress bar
+        self.total_crns = len(self.crns)
+        self.progress_bar.total = self.total_crns
+        self.loader_label_start.update(f"Fetching data of {self.total_crns} nodes ")
         self.tasks = set()
+
+        # Fetch all CRNs
         for node in list(self.crns.values()):
-            # Machine usage
             task = asyncio.create_task(self.fetch_node_info(node))
             self.tasks.add(task)
-            task.add_done_callback(self.tasks.discard)
             task.add_done_callback(self.make_progress)
-            # Resource
-
-            task = asyncio.create_task(self.fetch_node_config(node))
-            self.tasks.add(task)
             task.add_done_callback(self.tasks.discard)
-            task.add_done_callback(self.make_progress)
 
     async def fetch_node_info(self, node: CRNInfo):
         try:
-            node_url = sanitize_url(node.url)
-        except InvalidURL:
-            logger.debug(f"Skipping node {node.hash}, invalid url")
+            crn_info = await fetch_crn_info(node.url)
+        except:
             return
+        if crn_info:
+            node.version = crn_info.get("version", "")
+            node.stream_reward_address = extract_valid_eth_address(
+                crn_info.get("payment", {}).get("PAYMENT_RECEIVER_ADDRESS") or node.stream_reward_address or ""
+            )
+            node.qemu_support = crn_info.get("computing", {}).get("ENABLE_QEMU_SUPPORT", False)
+            node.confidential_computing = crn_info.get("computing", {}).get("ENABLE_CONFIDENTIAL_COMPUTING", False)
+            node.machine_usage = crn_info.get("machine_usage")
 
-        # Skip nodes without a reward address
-        if not node.stream_reward_address:
-            logger.debug(f"Skipping node {node.hash}, no reward address")
-            return
+            # Skip nodes without machine usage
+            if not node.machine_usage:
+                logger.debug(f"Skipping node {node.hash}, no machine usage")
+                return
 
-        # Fetch the machine usage and version from its HTTP API
-        machine_usage, version = await fetch_crn_info(node_url)
+            self.active_crns += 1
+            # Skip nodes without reward address if only_reward_address is set
+            if self.only_reward_address and not node.stream_reward_address:
+                logger.debug(f"Skipping node {node.hash}, no reward address")
+                return
+            # Skip non-qemu nodes if only_qemu is set
+            if self.only_qemu and not node.qemu_support:
+                logger.debug(f"Skipping node {node.hash}, no qemu support")
+                return
+            # Skip non-confidential nodes if only_confidentials is set
+            if self.only_confidentials and not node.confidential_computing:
+                logger.debug(f"Skipping node {node.hash}, no confidential support")
+                return
+            self.filtered_crns += 1
 
-        if not machine_usage:
-            logger.debug(f"Skipping node {node.hash}, no machine usage")
-            return
-        node.machine_usage = MachineUsage.parse_obj(machine_usage)
-        node.version = version
+            self.table.add_row(
+                _format_score(node.score),
+                node.name,
+                node.version,
+                node.stream_reward_address,
+                "✅" if node.confidential_computing else "✖",
+                "✅" if node.qemu_support else "✖",
+                node.display_cpu,
+                node.display_ram,
+                node.display_hdd,
+                node.url,
+                key=node.hash,
+            )
 
-        cpu, hdd, ram = convert_system_info_to_str(node)
-
-        self.table.update_cell(row_key=node.hash, column_key="cpu", value=cpu)
-        self.table.update_cell(row_key=node.hash, column_key="hdd", value=hdd)
-        self.table.update_cell(row_key=node.hash, column_key="ram", value=ram)
-        self.table.update_cell(row_key=node.hash, column_key="version", value=node.version)
-
-    async def fetch_node_config(self, node: CRNInfo):
+    def make_progress(self, task):
+        """Called automatically to advance the progress bar."""
         try:
-            node_url = sanitize_url(node.url)
-        except InvalidURL:
-            logger.debug(f"Skipping node {node.hash}, invalid url")
-            return
+            self.progress_bar.advance(1)
+            self.loader_label_end.update(f"    Available: {self.active_crns}    Match: {self.filtered_crns}")
+        except NoMatches:
+            pass
+        if len(self.tasks) == 0:
+            self.loader_label_start.update(f"Fetched {self.total_crns} nodes ")
 
-        # Skip nodes without a reward address
-        if not node.stream_reward_address:
-            logger.debug(f"Skipping node {node.hash}, no reward address")
-            return
-
-        crn_config = await fetch_crn_config(node_url)
-        if crn_config:
-            # The computing is only available on aleph-vm > 0.4.1
-            node.confidential_computing = crn_config.get("computing", {}).get("ENABLE_CONFIDENTIAL_COMPUTING")
-        confidential_computing = "Y" if node.confidential_computing else "N"
-
-        self.table.update_cell(row_key=node.hash, column_key="confidential_computing", value=confidential_computing)
-
-    def on_data_table_row_selected(self, message: DataTable.RowSelected) -> None:
+    def on_data_table_row_selected(self, message: DataTable.RowSelected):
         """Return the selected row"""
         selected_crn: Optional[CRNInfo] = self.crns.get(message.row_key)
         self.exit(selected_crn)
 
-    def make_progress(self, task) -> None:
-        """Called automatically to advance the progress bar."""
-        try:
-            self.query_one(ProgressBar).advance(1)
-        except NoMatches:
-            pass
-        if len(self.tasks) == 0:
-            self.loader_label.update("Fetched ")
+    def sort_reverse(self, sort_type: str) -> bool:
+        """Determine if `sort_type` is ascending or descending."""
+        reverse = sort_type in self.current_sorts
+        if reverse:
+            self.current_sorts.remove(sort_type)
+        else:
+            self.current_sorts.add(sort_type)
+        return reverse
+
+    def sort_by(self, column, sort_func=lambda row: row.lower(), invert=False):
+        table = self.query_one(DataTable)
+        reverse = self.sort_reverse(column)
+        table.sort(
+            column,
+            key=sort_func,
+            reverse=not reverse if invert else reverse,
+        )
+
+    def action_sort_by_score(self):
+        self.sort_by("score", sort_func=lambda row: float(row.plain.rstrip("%")), invert=True)
+
+    def action_sort_by_name(self):
+        self.sort_by("name")
+
+    def action_sort_by_version(self):
+        self.sort_by("version")
+
+    def action_sort_by_address(self):
+        self.sort_by("stream_reward_address")
+
+    def action_sort_by_confidential(self):
+        self.sort_by("confidential_computing")
+
+    def action_sort_by_qemu(self):
+        self.sort_by("qemu_support")
+
+    def action_sort_by_url(self):
+        self.sort_by("url")

--- a/src/aleph_client/commands/instance/display.py
+++ b/src/aleph_client/commands/instance/display.py
@@ -37,7 +37,7 @@ class CRNTable(App[CRNInfo]):
         ("n", "sort_by_name", "Sort By Name"),
         ("v", "sort_by_version", "Sort By Version"),
         ("a", "sort_by_address", "Sort By Address"),
-        ("c", "sort_by_confidential", "Sort By 🔒"),
+        ("c", "sort_by_confidential", "Sort By 🔒 Confidential"),
         ("q", "sort_by_qemu", "Sort By Qemu"),
         ("u", "sort_by_url", "Sort By URL"),
         ("x", "quit", "Exit"),

--- a/src/aleph_client/commands/instance/network.py
+++ b/src/aleph_client/commands/instance/network.py
@@ -1,21 +1,16 @@
 from __future__ import annotations
 
-import asyncio
 import logging
-import re
-import typing
 from json import JSONDecodeError
-from typing import List, Literal, Optional, Tuple, Union
+from typing import Optional
 from urllib.parse import ParseResult, urlparse
 
 import aiohttp
 from aiohttp import InvalidURL
-from multidict import CIMultiDictProxy
 from pydantic import ValidationError
 
-from aleph_client.commands.node import NodeInfo
 from aleph_client.conf import settings
-from aleph_client.models import MachineInfo, MachineUsage
+from aleph_client.models import MachineUsage
 
 logger = logging.getLogger(__name__)
 
@@ -35,97 +30,49 @@ FORBIDDEN_HOSTS = [
     "youtube.com",
 ]
 
-# This type annotation is hidden behind typing.TYPE_CHECKING for compatibility with Python 3.8
-if typing.TYPE_CHECKING:
-    # A queue is used to pass the machine info from the coroutines that fetch it to the
-    # coroutine in charge of updating the table and progress bar.
-    # Invalid URLs are represented as None, and the end of the queue is marked with "END_OF_QUEUE".
-    MachineInfoQueue = asyncio.Queue[Union[MachineInfo, None, Literal["END_OF_QUEUE"]]]
+PATH_STATUS_CONFIG = "/status/config"
+PATH_ABOUT_USAGE_SYSTEM = "/about/usage/system"
 
 
-def get_version(headers: CIMultiDictProxy[str]) -> Optional[str]:
-    """Extracts the version of the CRN from the headers of the response.
-
-    Args:
-        headers: aiohttp response headers.
-    Returns:
-        Version of the CRN if found, None otherwise.
-    """
-    if "Server" in headers:
-        for server in headers.getall("Server"):
-            version_match: List[str] = re.findall(r"^aleph-vm/(.*)$", server)
-            # Return the first match
-            if version_match and version_match[0]:
-                return version_match[0]
-    return None
-
-
-async def fetch_crn_info(node_url: str) -> Tuple[Optional[MachineUsage], Optional[str]]:
+async def fetch_crn_info(node_url: str) -> Optional[dict]:
     """
     Fetches compute node usage information and version.
 
     Args:
         node_url: URL of the compute node.
     Returns:
-        Machine usage information and version.
+        All CRN information.
     """
-    # Remove trailing slashes to avoid having // in the URL.
-    url: str = node_url.rstrip("/") + "/about/usage/system"
-    timeout = aiohttp.ClientTimeout(total=settings.HTTP_REQUEST_TIMEOUT)
+    url = ""
     try:
-        # A new session is created for each request since they each target a different host.
+        base_url: str = sanitize_url(node_url.rstrip("/"))
+        timeout = aiohttp.ClientTimeout(total=settings.HTTP_REQUEST_TIMEOUT)
         async with aiohttp.ClientSession(timeout=timeout) as session:
+            info: dict
+            url = base_url + PATH_STATUS_CONFIG
             async with session.get(url) as resp:
                 resp.raise_for_status()
-                data_raw: dict = await resp.json()
-                version = get_version(resp.headers)
-                return MachineUsage.parse_obj(data_raw), version
-    except TimeoutError as e:
-        logger.debug(f"Timeout while fetching: {url}: {e}")
-    except aiohttp.ClientConnectionError as e:
-        logger.debug(f"Error on connection: {url}: {e}")
-    except aiohttp.ClientResponseError as e:
-        logger.debug(f"Error on response: {url}: {e}")
-    except JSONDecodeError as e:
-        logger.debug(f"Error decoding JSON: {url}: {e}")
-    except ValidationError as e:
-        logger.debug(f"Validation error when fetching: {url}: {e}")
-    except InvalidURL as e:
-        logger.debug(f"Invalid URL: {url}: {e}")
-    return None, None
-
-
-async def fetch_crn_config(node_url: str) -> Optional[dict]:
-    """
-    Fetches compute node usage information and version.
-
-    Args:
-        node_url: URL of the compute node.
-    Returns:
-        Node public configuration
-    """
-    # Remove trailing slashes to avoid having // in the URL.
-    url: str = node_url.rstrip("/") + "/status/config"
-    timeout = aiohttp.ClientTimeout(total=settings.HTTP_REQUEST_TIMEOUT)
-    try:
-        # A new session is created for each request since they each target a different host.
-        async with aiohttp.ClientSession(timeout=timeout) as session:
+                info = await resp.json()
+            url = base_url + PATH_ABOUT_USAGE_SYSTEM
             async with session.get(url) as resp:
                 resp.raise_for_status()
-                data_raw: dict = await resp.json()
-                return data_raw
-    except TimeoutError as e:
-        logger.debug(f"Timeout while fetching: {url}: {e}")
-    except aiohttp.ClientConnectionError as e:
-        logger.debug(f"Error on connection: {url}: {e}")
-    except aiohttp.ClientResponseError as e:
-        logger.debug(f"Error on response: {url}: {e}")
-    except JSONDecodeError as e:
-        logger.debug(f"Error decoding JSON: {url}: {e}")
-    except ValidationError as e:
-        logger.debug(f"Validation error when fetching: {url}: {e}")
+                system: dict = await resp.json()
+                info["machine_usage"] = MachineUsage.parse_obj(system)
+            return info
     except InvalidURL as e:
-        logger.debug(f"Invalid URL: {url}: {e}")
+        logger.debug(f"Invalid CRN URL: {url}: {e}")
+    except TimeoutError as e:
+        logger.debug(f"Timeout while fetching CRN: {url}: {e}")
+    except aiohttp.ClientConnectionError as e:
+        logger.debug(f"Error on CRN connection: {url}: {e}")
+    except aiohttp.ClientResponseError as e:
+        logger.debug(f"Error on CRN response: {url}: {e}")
+    except JSONDecodeError as e:
+        logger.debug(f"Error decoding CRN JSON: {url}: {e}")
+    except ValidationError as e:
+        logger.debug(f"Validation error when fetching CRN: {url}: {e}")
+    except Exception as e:
+        logger.debug(f"Unexpected error when fetching CRN: {url}: {e}")
     return None
 
 
@@ -139,77 +86,13 @@ def sanitize_url(url: str) -> str:
     """
     if not url:
         raise InvalidURL("Empty URL")
-
-    # Use urllib3 to parse the URL.
-    # This should raise the same InvalidURL exception if the URL is invalid.
     parsed_url: ParseResult = urlparse(url)
-
     if parsed_url.scheme not in ["http", "https"]:
         raise InvalidURL(f"Invalid URL scheme: {parsed_url.scheme}")
-
     if parsed_url.hostname in FORBIDDEN_HOSTS:
         logger.debug(
             f"Invalid URL {url} hostname {parsed_url.hostname} is in the forbidden host list "
             f"({', '.join(FORBIDDEN_HOSTS)})"
         )
         raise InvalidURL("Invalid URL host")
-
     return url
-
-
-async def fetch_crn_info_in_queue(node: dict, queue: MachineInfoQueue) -> None:
-    """Fetch the resource usage from a CRN and put it in the queue
-
-    Args:
-        node: Information about the CRN from the 'corechannel' aggregate.
-        queue: Queue used to update the table live.
-    """
-    # Skip nodes without an address or with an invalid address
-    try:
-        node_url = sanitize_url(node["address"])
-    except InvalidURL:
-        logger.info(f"Invalid URL: {node['address']}")
-        await queue.put(None)
-        return
-
-    # Skip nodes without a reward address
-    if not node["stream_reward"]:
-        await queue.put(None)
-        return
-
-    # Fetch the machine usage and version from its HTTP API
-    machine_usage, version = await fetch_crn_info(node_url)
-
-    if not machine_usage:
-        await queue.put(None)
-        return
-
-    await queue.put(
-        MachineInfo.from_unsanitized_input(
-            machine_usage=machine_usage,
-            hash=node["hash"],
-            score=node["score"],
-            name=node["name"],
-            version=version,
-            reward_address=node["stream_reward"],
-            url=node["address"],
-        )
-    )
-
-
-async def fetch_and_queue_crn_info(
-    node_info: NodeInfo,
-    queue: MachineInfoQueue,
-):
-    """Fetch the resource usage of all CRNs in the node_info asynchronously
-    and put them in the queue.
-
-    Fetches the resource usage and version of each node in parallel using a separate coroutine.
-
-    Args:
-        node_info: Information about all CRNs from the 'corechannel' aggregate.
-        queue: Queue used to update the table live.
-    """
-    coroutines = [fetch_crn_info_in_queue(node, queue) for node in node_info.nodes]
-    await asyncio.gather(*coroutines)
-    await queue.put("END_OF_QUEUE")

--- a/src/aleph_client/commands/message.py
+++ b/src/aleph_client/commands/message.py
@@ -62,7 +62,9 @@ async def find(
     end_date: Optional[str] = None,
     ignore_invalid_messages: bool = True,
 ):
-    parsed_message_types = message_types.split(",") if message_types else None
+    parsed_message_types = (
+        [MessageType(message_type) for message_type in message_types.split(",")] if message_types else None
+    )
     parsed_content_types = content_types.split(",") if content_types else None
     parsed_content_keys = content_keys.split(",") if content_keys else None
     parsed_refs = refs.split(",") if refs else None
@@ -72,10 +74,6 @@ async def find(
     parsed_channels = channels.split(",") if channels else None
     parsed_chains = chains.split(",") if chains else None
 
-    message_types = (
-        [MessageType(message_type) for message_type in parsed_message_types] if parsed_message_types else None
-    )
-
     start_time = str_to_datetime(start_date)
     end_time = str_to_datetime(end_date)
 
@@ -84,7 +82,7 @@ async def find(
             page_size=pagination,
             page=page,
             message_filter=MessageFilter(
-                message_types=message_types,
+                message_types=parsed_message_types,
                 content_types=parsed_content_types,
                 content_keys=parsed_content_keys,
                 refs=parsed_refs,

--- a/src/aleph_client/commands/utils.py
+++ b/src/aleph_client/commands/utils.py
@@ -202,7 +202,7 @@ def is_environment_interactive() -> bool:
     )
 
 
-def has_nested_attr(obj, attr_chain) -> bool:
+def has_nested_attr(obj, *attr_chain) -> bool:
     for attr in attr_chain:
         if not hasattr(obj, attr) or getattr(obj, attr) is None:
             return False

--- a/src/aleph_client/conf.py
+++ b/src/aleph_client/conf.py
@@ -54,7 +54,7 @@ class Settings(BaseSettings):
         case_sensitive = False
         env_file = ".env"
 
-    HTTP_REQUEST_TIMEOUT = 5.0
+    HTTP_REQUEST_TIMEOUT = 10.0
 
 
 # Settings singleton

--- a/src/aleph_client/models.py
+++ b/src/aleph_client/models.py
@@ -117,29 +117,20 @@ class CRNInfo(BaseModel):
 
     @property
     def display_cpu(self) -> str:
-        try:
-            if self.machine_usage:
-                return f"{self.machine_usage.cpu.count:>3}"
-        except:
-            pass
+        if self.machine_usage:
+            return f"{self.machine_usage.cpu.count:>3}"
         return ""
 
     @property
     def display_ram(self) -> str:
-        try:
-            if self.machine_usage:
-                return f"{self.machine_usage.mem.available_kB / 1_000_000:>3.0f} / {self.machine_usage.mem.total_kB / 1_000_000:>3.0f} GB"
-        except:
-            pass
+        if self.machine_usage:
+            return f"{self.machine_usage.mem.available_kB / 1_000_000:>3.0f} / {self.machine_usage.mem.total_kB / 1_000_000:>3.0f} GB"
         return ""
 
     @property
     def display_hdd(self) -> str:
-        try:
-            if self.machine_usage:
-                return f"{self.machine_usage.disk.available_kB / 1_000_000:>4.0f} / {self.machine_usage.disk.total_kB / 1_000_000:>4.0f} GB"
-        except:
-            pass
+        if self.machine_usage:
+            return f"{self.machine_usage.disk.available_kB / 1_000_000:>4.0f} / {self.machine_usage.disk.total_kB / 1_000_000:>4.0f} GB"
         return ""
 
     def display_crn_specs(self):

--- a/src/aleph_client/models.py
+++ b/src/aleph_client/models.py
@@ -1,12 +1,12 @@
 from datetime import datetime
 from typing import Optional
 
+from aleph_message.models import ItemHash
 from aleph_message.models.execution.environment import CpuProperties
 from pydantic import BaseModel
+from typer import echo
 
 from aleph_client.commands.node import _escape_and_normalize, _remove_ansi_escape
-
-# This is a copy from aleph-vm
 
 
 class LoadAverage(BaseModel):
@@ -102,3 +102,56 @@ class MachineInfo(BaseModel):
             url=url,
             hash=hash,
         )
+
+
+class CRNInfo(BaseModel):
+    hash: ItemHash
+    name: str
+    url: str
+    version: Optional[str]
+    score: float
+    stream_reward_address: str
+    machine_usage: Optional[MachineUsage]
+    qemu_support: Optional[bool]
+    confidential_computing: Optional[bool]
+
+    @property
+    def display_cpu(self) -> str:
+        try:
+            if self.machine_usage:
+                return f"{self.machine_usage.cpu.count:>3}"
+        except:
+            pass
+        return ""
+
+    @property
+    def display_ram(self) -> str:
+        try:
+            if self.machine_usage:
+                return f"{self.machine_usage.mem.available_kB / 1_000_000:>3.0f} / {self.machine_usage.mem.total_kB / 1_000_000:>3.0f} GB"
+        except:
+            pass
+        return ""
+
+    @property
+    def display_hdd(self) -> str:
+        try:
+            if self.machine_usage:
+                return f"{self.machine_usage.disk.available_kB / 1_000_000:>4.0f} / {self.machine_usage.disk.total_kB / 1_000_000:>4.0f} GB"
+        except:
+            pass
+        return ""
+
+    def display_crn_specs(self):
+        echo(f"Hash: {self.hash}")
+        echo(f"Name: {self.name}")
+        echo(f"URL: {self.url}")
+        echo(f"Version: {self.version}")
+        echo(f"Score: {self.score}")
+        echo(f"Stream receiver: {self.stream_reward_address}")
+        if isinstance(self.machine_usage, MachineUsage):
+            echo(f"Available Cores: {self.display_cpu}")
+            echo(f"Available RAM: {self.display_ram}")
+            echo(f"Available Disk: {self.display_hdd}")
+        echo(f"Support Qemu: {self.qemu_support}")
+        echo(f"Support Confidential: {self.confidential_computing}")

--- a/src/aleph_client/utils.py
+++ b/src/aleph_client/utils.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 import logging
 import os
+import re
 from functools import partial, wraps
 from pathlib import Path
 from shutil import make_archive
@@ -91,3 +92,12 @@ async def fetch_json(session: ClientSession, url: str) -> dict:
     async with session.get(url) as resp:
         resp.raise_for_status()
         return await resp.json()
+
+
+def extract_valid_eth_address(address: str) -> str:
+    if address:
+        pattern = r"0x[a-fA-F0-9]{40}"
+        match = re.search(pattern, address)
+        if match:
+            return match.group(0)
+    return ""

--- a/src/aleph_client/utils.py
+++ b/src/aleph_client/utils.py
@@ -10,7 +10,7 @@ from typing import Tuple, Type
 from zipfile import BadZipFile, ZipFile
 
 import typer
-from aiohttp import ClientResponseError, ClientSession
+from aiohttp import ClientSession
 from aleph.sdk.types import GenericMessage
 from aleph_message.models.base import MessageType
 from aleph_message.models.execution.base import Encoding

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -10,7 +10,6 @@ from multidict import CIMultiDict, CIMultiDictProxy
 from aleph_client.commands.instance.network import (
     FORBIDDEN_HOSTS,
     fetch_crn_info,
-    get_version,
     sanitize_url,
 )
 from aleph_client.models import (
@@ -68,39 +67,21 @@ def dict_to_ci_multi_dict_proxy(d: dict) -> CIMultiDictProxy:
     return CIMultiDictProxy(CIMultiDict(d))
 
 
-def test_get_version() -> None:
-
-    # No server field in headers
-    headers = dict_to_ci_multi_dict_proxy({})
-    assert get_version(headers) is None
-
-    # Server header but no aleph-vm
-    headers = dict_to_ci_multi_dict_proxy({"Server": "nginx"})
-    assert get_version(headers) is None
-
-    # Server header with aleph-vm
-    headers = dict_to_ci_multi_dict_proxy({"Server": "aleph-vm/0.1.0"})
-    assert get_version(headers) == "0.1.0"
-
-    # Server header multiple aleph-vm values
-    headers = dict_to_ci_multi_dict_proxy({"Server": "aleph-vm/0.1.0", "server": "aleph-vm/0.2.0"})
-    assert get_version(headers) == "0.1.0"
-
-
 @pytest.mark.asyncio
 async def test_fetch_crn_info() -> None:
     # Test with valid node
     # TODO: Mock the response from the node, don't rely on a real node
     node_url = "https://ovh.staging.aleph.sh"
-    machine_usage, version = await fetch_crn_info(node_url)
-    assert machine_usage is not None
-    assert version is not None
-    assert isinstance(machine_usage, MachineUsage)
-    assert isinstance(version, str)
+    info = await fetch_crn_info(node_url)
+    assert info
+    assert hasattr(info, "machine_usage") and info.machine_usage
+    assert hasattr(info, "version") and info.version
+    assert isinstance(info.machine_usage, MachineUsage)
+    assert isinstance(info.version, str)
 
     # Test with invalid node
     invalid_node_url = "https://coconut.example.org/"
-    assert await fetch_crn_info(invalid_node_url) == (None, None)
+    assert not (await fetch_crn_info(invalid_node_url))
 
     # TODO: Test different error handling
 

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -74,10 +74,7 @@ async def test_fetch_crn_info() -> None:
     node_url = "https://ovh.staging.aleph.sh"
     info = await fetch_crn_info(node_url)
     assert info
-    assert hasattr(info, "machine_usage") and info.machine_usage
-    assert hasattr(info, "version") and info.version
-    assert isinstance(info.machine_usage, MachineUsage)
-    assert isinstance(info.version, str)
+    assert info["machine_usage"]
 
     # Test with invalid node
     invalid_node_url = "https://coconut.example.org/"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ef70f880-a8bc-45fc-871d-ba266645e35e)

## Changes

- Cleaning / rewritting / simplification of commands -> instance -> display.py / network.py
- Properly retrieve CRN data
- Fix broken CRNTable
- Add sort_by keys (score, name, version, address, coco, qemu, url)
- Add auto-filtering for reward address, qemu support and confidential support

## How to test

Try to create a PAYG or coco instance without specifying crn_hash and crn_url. It will display the new CRNTable.

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [ ] All new code is covered by relevant tests.
- [ ] Documentation has been updated regarding these changes.