### PR TITLE
fix(pyproject): max aleph-sdk-python versiont to respect semver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "aleph-sdk-python>=1.0.0",
+  "aleph-sdk-python>=1.0.0,<2",
   "setuptools>=65.5.0",
   "aleph-message>=0.4.9",
   "aiohttp==3.9.5",


### PR DESCRIPTION
We don't have an upper hand version for our own dependency which mean we can't
safely release a breaking version of aleph-sdk-python because that would break
this package.

## Self proofreading checklist

- [X] The new code clear, easy to read and well commented.
- [X] New code does not duplicate the functions of builtin or popular libraries.

## Changes

Set the max version of this dependency to inferior of the next major version.

## How to test

Just install this version with pip (but the CI will do that for you)
