### PR TITLE
Refactor: aleph message get to handle message status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "aleph-sdk-python>=1.0.0",
+  "aleph-sdk-python>=1.0.1",
   "setuptools>=65.5.0",
   "aleph-message>=0.4.9",
   "aiohttp==3.9.5",

--- a/src/aleph_client/commands/message.py
+++ b/src/aleph_client/commands/message.py
@@ -27,7 +27,7 @@ from aleph_client.commands import help_strings
 from aleph_client.commands.utils import (
     colorful_json,
     colorful_message_json,
-    colorize_status,
+    colorized_status,
     input_multiline,
     setup_logging,
     str_to_datetime,
@@ -38,14 +38,13 @@ from aleph_client.utils import AsyncTyper
 app = AsyncTyper(no_args_is_help=True)
 
 
-
 @app.command()
 async def get(
     item_hash: str = typer.Argument(..., help="Item hash of the message"),
 ):
     async with AlephHttpClient(api_server=sdk_settings.API_HOST) as client:
         message, status = await client.get_message(item_hash=ItemHash(item_hash), with_status=True)
-        typer.echo(f"Message Status: {colorize_status(status)}")
+        typer.echo(f"Message Status: {colorized_status(status)}")
         if status == MessageStatus.REJECTED:
             reason = await client.get_message_error(item_hash=ItemHash(item_hash))
             typer.echo(colorful_json(json.dumps(reason, indent=4)))

--- a/src/aleph_client/commands/message.py
+++ b/src/aleph_client/commands/message.py
@@ -21,11 +21,13 @@ from aleph.sdk.utils import extended_json_encoder
 from aleph_message.models import AlephMessage, ProgramMessage
 from aleph_message.models.base import MessageType
 from aleph_message.models.item_hash import ItemHash
+from aleph_message.status import MessageStatus
 
 from aleph_client.commands import help_strings
 from aleph_client.commands.utils import (
     colorful_json,
     colorful_message_json,
+    colorize_status,
     input_multiline,
     setup_logging,
     str_to_datetime,
@@ -36,13 +38,19 @@ from aleph_client.utils import AsyncTyper
 app = AsyncTyper(no_args_is_help=True)
 
 
+
 @app.command()
 async def get(
     item_hash: str = typer.Argument(..., help="Item hash of the message"),
 ):
     async with AlephHttpClient(api_server=sdk_settings.API_HOST) as client:
-        message: AlephMessage = await client.get_message(item_hash=ItemHash(item_hash))
-    typer.echo(colorful_message_json(message))
+        message, status = await client.get_message(item_hash=ItemHash(item_hash), with_status=True)
+        typer.echo(f"Message Status: {colorize_status(status)}")
+        if status == MessageStatus.REJECTED:
+            reason = await client.get_message_error(item_hash=ItemHash(item_hash))
+            typer.echo(colorful_json(json.dumps(reason, indent=4)))
+        else:
+            typer.echo(colorful_message_json(message))
 
 
 @app.command()

--- a/src/aleph_client/commands/utils.py
+++ b/src/aleph_client/commands/utils.py
@@ -34,9 +34,7 @@ def colorful_json(obj: str):
     )
 
 
-
-
-def colorize_status(status: MessageStatus) -> str:
+def colorized_status(status: MessageStatus) -> str:
     """Return a colored status string based on its value."""
     status_colors = {
         MessageStatus.REJECTED: typer.colors.RED,

--- a/src/aleph_client/commands/utils.py
+++ b/src/aleph_client/commands/utils.py
@@ -13,6 +13,7 @@ from aleph.sdk.chains.ethereum import ETHAccount
 from aleph.sdk.conf import settings as sdk_settings
 from aleph.sdk.types import GenericMessage
 from aleph_message.models import ItemHash
+from aleph_message.status import MessageStatus
 from pygments import highlight
 from pygments.formatters.terminal256 import Terminal256Formatter
 from pygments.lexers import JsonLexer
@@ -31,6 +32,20 @@ def colorful_json(obj: str):
         lexer=JsonLexer(),
         formatter=Terminal256Formatter(),
     )
+
+
+
+
+def colorize_status(status: MessageStatus) -> str:
+    """Return a colored status string based on its value."""
+    status_colors = {
+        MessageStatus.REJECTED: typer.colors.RED,
+        MessageStatus.PROCESSED: typer.colors.GREEN,
+        MessageStatus.PENDING: typer.colors.YELLOW,
+        MessageStatus.FORGOTTEN: typer.colors.BRIGHT_BLACK,
+    }
+    color = status_colors.get(status, typer.colors.WHITE)
+    return typer.style(status, fg=color, bold=True)
 
 
 def colorful_message_json(message: GenericMessage):


### PR DESCRIPTION
When using aleph message get, it simply retrieves the message and does not return the status (and provides no information when it's rejected).


## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [ ] New classes and functions contain docstrings explaining what they provide.
- [ ] All new code is covered by relevant tests.

## Documentation

The documentation regarding the impacted features is available on:
> URL

The changes in the documentation are available here:
> URL

## Changes
Usage of the new overload implemented in [PR](https://github.com/aleph-im/aleph-sdk-python/pull/163) to get the message status, and if the status is rejected, we retrieve the message error.

## How to test
Install needed sdk parts
```shell
pip install git+https://github.com/aleph-im/aleph-sdk-python.git@1yam-message-status
```
```
aleph message get item_hash
```

## Print screen / video
![image](https://github.com/user-attachments/assets/c64ab18d-60c7-4d2e-a7c8-ca08d7a2db07)
![image](https://github.com/user-attachments/assets/0cf5fcd8-1780-43e2-998b-7aafaa8ebc71)

## Notes

This PR need [PR](https://github.com/aleph-im/aleph-sdk-python/pull/163) getting merged first
