### PR TITLE
Fix/volume prompt

### DIFF
--- a/src/aleph_client/commands/utils.py
+++ b/src/aleph_client/commands/utils.py
@@ -121,20 +121,20 @@ def volume_to_dict(volume: List[str]) -> Optional[Dict[str, Union[str, int]]]:
 def get_or_prompt_volumes(ephemeral_volume, immutable_volume, persistent_volume):
     volumes = []
     # Check if the volumes are empty
-    if persistent_volume is None or ephemeral_volume is None or immutable_volume is None:
+    if persistent_volume is None and ephemeral_volume is None and immutable_volume is None:
         for volume in prompt_for_volumes():
             volumes.append(volume)
             echo("\n")
 
     # else parse all the volumes that have passed as the cli parameters and put it into volume list
     else:
-        if len(persistent_volume) > 0:
+        if len(persistent_volume or []) > 0:
             persistent_volume_dict = volume_to_dict(volume=persistent_volume)
             volumes.append(persistent_volume_dict)
-        if len(ephemeral_volume) > 0:
+        if len(ephemeral_volume or []) > 0:
             ephemeral_volume_dict = volume_to_dict(volume=ephemeral_volume)
             volumes.append(ephemeral_volume_dict)
-        if len(immutable_volume) > 0:
+        if len(immutable_volume or []) > 0:
             immutable_volume_dict = volume_to_dict(volume=immutable_volume)
             volumes.append(immutable_volume_dict)
     return volumes
@@ -189,7 +189,8 @@ def validated_int_prompt(
     while True:
         try:
             value = IntPrompt.ask(
-                prompt + f" [min: {min_value or '-'}, max: {max_value or '-'}]",
+                prompt +
+                f" [min: {min_value or '-'}, max: {max_value or '-'}]",
                 default=default,
             )
         except PromptError:

--- a/src/aleph_client/commands/utils.py
+++ b/src/aleph_client/commands/utils.py
@@ -189,8 +189,7 @@ def validated_int_prompt(
     while True:
         try:
             value = IntPrompt.ask(
-                prompt +
-                f" [min: {min_value or '-'}, max: {max_value or '-'}]",
+                prompt + f" [min: {min_value or '-'}, max: {max_value or '-'}]",
                 default=default,
             )
         except PromptError:

--- a/src/aleph_client/commands/utils.py
+++ b/src/aleph_client/commands/utils.py
@@ -121,20 +121,20 @@ def volume_to_dict(volume: List[str]) -> Optional[Dict[str, Union[str, int]]]:
 def get_or_prompt_volumes(ephemeral_volume, immutable_volume, persistent_volume):
     volumes = []
     # Check if the volumes are empty
-    if persistent_volume is None and ephemeral_volume is None and immutable_volume is None:
+    if not any([persistent_volume, ephemeral_volume, immutable_volume]):
         for volume in prompt_for_volumes():
             volumes.append(volume)
             echo("\n")
 
     # else parse all the volumes that have passed as the cli parameters and put it into volume list
     else:
-        if len(persistent_volume or []) > 0:
+        if persistent_volume:
             persistent_volume_dict = volume_to_dict(volume=persistent_volume)
             volumes.append(persistent_volume_dict)
-        if len(ephemeral_volume or []) > 0:
+        if ephemeral_volume:
             ephemeral_volume_dict = volume_to_dict(volume=ephemeral_volume)
             volumes.append(ephemeral_volume_dict)
-        if len(immutable_volume or []) > 0:
+        if immutable_volume:
             immutable_volume_dict = volume_to_dict(volume=immutable_volume)
             volumes.append(immutable_volume_dict)
     return volumes


### PR DESCRIPTION
Skip prompts for program volumes when at least one volume is passed in command line parameters. 
It caused a but where the parameters are only taken into account if all three are passed.

Fixes: https://github.com/aleph-im/aleph-client/issues/230

Ideally: the `--non-interactive` option from https://github.com/aleph-im/aleph-client/pull/197 would provide a more predictable behaviour.

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.


## Changes

If one of `--immutable-volume`, `--persistent-volume` or `--ephemeral-volume` is passed as a parameter, skip the volume prompt and take these inputs instead. 

## How to test

Example:
`aleph program upload app main:app --immutable-volume ref=$VOLUME_ITEM_HASH,mount=/opt/packages`

