### PR TITLE
Fix: add 3sec delay in instance coco cmd to ensure VM is starting

### DIFF
--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -1241,6 +1241,9 @@ async def confidential_create(
         echo("Could not initialize the session")
         return 1
 
+    # Safe delay to ensure instance is starting and is ready
+    await asyncio.sleep(3)
+
     await confidential_start(
         vm_id=vm_id,
         domain=crn_url,


### PR DESCRIPTION
## Bug

- When using `aleph instance confidential`, the cmd fails at confidential_start() (after confidential_init_session()) returning "bad request"

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.

## Changes

- Add 3sec delay before confidential_start() in `aleph instance confidential` cmd to ensure VM is starting.