### PR TITLE
Fix: name/mount required on instance's volumes + Fix macos CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,7 @@ on:
     # Run every night at 04:00 (GitHub Actions timezone)
     # in order to catch when unfrozen dependency updates
     # break the use of the library.
-    - cron: '4 0 * * *'
+    - cron: "4 0 * * *"
 
 
 jobs:
@@ -38,6 +38,12 @@ jobs:
           brew tap cuber/homebrew-libsecp256k1
           brew install libsecp256k1
           brew install automake
+
+      - name: Set up Python for macOS
+        if: startsWith(matrix.os, 'macos')
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
 
       - run: python3 -m venv /tmp/venv
       - run: /tmp/venv/bin/python -m pip install --upgrade pip hatch coverage

--- a/src/aleph_client/commands/help_strings.py
+++ b/src/aleph_client/commands/help_strings.py
@@ -10,13 +10,14 @@ CUSTOM_DOMAIN_NAME = "Domain name. ex: aleph.im"
 CUSTOM_DOMAIN_ITEM_HASH = "Item hash"
 SKIP_VOLUME = "Skip prompt to attach more volumes"
 PERSISTENT_VOLUME = """Persistent volumes are allocated on the host machine and are not deleted when the VM is stopped.\n
-Requires at least a "mount" and "size_mib". For more info, see the docs: https://docs.aleph.im/computing/volumes/persistent/\n
-Example: --persistent_volume persistence=host,size_mib=100,mount=/opt/data"""
+Requires at least "name", "persistence", "mount" and "size_mib". For more info, see the docs: https://docs.aleph.im/computing/volumes/persistent/\n
+Example: --persistent_volume name=data,persistence=host,size_mib=100,mount=/opt/data"""
 EPHEMERAL_VOLUME = """Ephemeral volumes are allocated on the host machine when the VM is started and deleted when the VM is stopped.\n
-Example: --ephemeral-volume size_mib=100,mount=/tmp/data"""
+Requires at least "name", "mount" and "size_mib".\n
+Example: --ephemeral-volume name=temp,size_mib=100,mount=/tmp/data"""
 IMMUTABLE_VOLUME = """Immutable volumes are pinned on the network and can be used by multiple VMs at the same time. They are read-only and useful for setting up libraries or other dependencies.\n
-Requires at least a "ref" (message hash) and "mount" path. "use_latest" is True by default, to use the latest version of the volume, if it has been amended. See the docs for more info: https://docs.aleph.im/computing/volumes/immutable/\n
-Example: --immutable-volume ref=25a393222692c2f73489dc6710ae87605a96742ceef7b91de4d7ec34bb688d94,mount=/lib/python3.8/site-packages"""
+Requires at least "name", "ref" (message hash) and "mount" path. "use_latest" is True by default, to use the latest version of the volume, if it has been amended. See the docs for more info: https://docs.aleph.im/computing/volumes/immutable/\n
+Example: --immutable-volume name=libs,ref=25a393222692c2f73489dc6710ae87605a96742ceef7b91de4d7ec34bb688d94,mount=/lib/python3.8/site-packages"""
 ASK_FOR_CONFIRMATION = "Prompt user for confirmation"
 IPFS_CATCH_ALL_PATH = "Choose a relative path to catch all unmatched route or a 404 error"
 PAYMENT_TYPE = "Payment method, either holding tokens, NFTs, or Pay-As-You-Go via token streaming"


### PR DESCRIPTION
- name/mount are now required when providing volumes to an instance
- fix python version (3.13 -> 3.11) for macos 13/14 CI