### PR TITLE
fix(commands/instance): Wrong ssh option description

### DIFF
--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -722,7 +722,7 @@ async def _show_instances(messages: List[InstanceMessage], node_list: NodeInfo):
             "  ssh root@",
             Text("<ipv6-address>", style="yellow"),
             " -i ",
-            Text("<ssh-pubkey-file>", style="orange3"),
+            Text("<ssh-private-key-file>", style="orange3"),
             "\n",
             style="italic",
         ),


### PR DESCRIPTION
## Changes

The `-i` option in `ssh` is used to specify the path to the private key file, not the public one
