### PR TITLE
Implement GPU support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,16 +33,16 @@ dynamic = [ "version" ]
 dependencies = [
   "aiodns==3.2",
   "aiohttp==3.10.6",
-  "aleph-message @ git+https://github.com/aleph-im/aleph-message@andres-feature-add_gpu_requirement",
-  "aleph-sdk-python @ git+https://github.com/aleph-im/aleph-sdk-python@andres-feature-implement_gpu_support",
-  "base58==2.1.1",                                                                                            # Needed now as default with _load_account changement
-  "py-sr25519-bindings==0.2",                                                                                 # Needed for DOT signatures
+  "aleph-message>=0.6",
+  "aleph-sdk-python>=1.2.1,<2",
+  "base58==2.1.1",               # Needed now as default with _load_account changement
+  "py-sr25519-bindings==0.2",    # Needed for DOT signatures
   "pygments==2.18",
-  "pynacl==1.5",                                                                                              # Needed now as default with _load_account changement
+  "pynacl==1.5",                 # Needed now as default with _load_account changement
   "python-magic==0.4.27",
   "rich==13.9.3",
   "setuptools>=65.5",
-  "substrate-interface==1.7.11",                                                                              # Needed for DOT signatures
+  "substrate-interface==1.7.11", # Needed for DOT signatures
   "textual==0.73",
   "typer==0.12.5",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,16 +33,16 @@ dynamic = [ "version" ]
 dependencies = [
   "aiodns==3.2",
   "aiohttp==3.10.6",
-  "aleph-message>=0.5",
-  "aleph-sdk-python>=1.2,<2",
-  "base58==2.1.1",               # Needed now as default with _load_account changement
-  "py-sr25519-bindings==0.2",    # Needed for DOT signatures
+  "aleph-message @ git+https://github.com/aleph-im/aleph-message@andres-feature-add_gpu_requirement",
+  "aleph-sdk-python @ git+https://github.com/aleph-im/aleph-sdk-python@andres-feature-implement_gpu_support",
+  "base58==2.1.1",                                                                                            # Needed now as default with _load_account changement
+  "py-sr25519-bindings==0.2",                                                                                 # Needed for DOT signatures
   "pygments==2.18",
-  "pynacl==1.5",                 # Needed now as default with _load_account changement
+  "pynacl==1.5",                                                                                              # Needed now as default with _load_account changement
   "python-magic==0.4.27",
   "rich==13.9.3",
   "setuptools>=65.5",
-  "substrate-interface==1.7.11", # Needed for DOT signatures
+  "substrate-interface==1.7.11",                                                                              # Needed for DOT signatures
   "textual==0.73",
   "typer==0.12.5",
 ]

--- a/src/aleph_client/commands/help_strings.py
+++ b/src/aleph_client/commands/help_strings.py
@@ -39,6 +39,7 @@ CONFIDENTIAL_OPTION = "Launch a confidential instance (requires creating an encr
 CONFIDENTIAL_FIRMWARE = "Hash to UEFI Firmware to launch confidential instance"
 CONFIDENTIAL_FIRMWARE_HASH = "Hash of the UEFI Firmware content, to validate measure (ignored if path is provided)"
 CONFIDENTIAL_FIRMWARE_PATH = "Path to the UEFI Firmware content, to validate measure (instead of the hash)"
+GPU_OPTION = "Launch an instance attaching a GPU to it"
 KEEP_SESSION = "Keeping the already initiated session"
 VM_SECRET = "Secret password to start the VM"
 CRN_URL_VM_DELETION = "Domain of the CRN where an associated VM is running. It ensures your VM will be stopped and erased on the CRN before the instance message is actually deleted"

--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -31,6 +31,7 @@ from aleph_message.models import InstanceMessage, StoreMessage
 from aleph_message.models.base import Chain, MessageType
 from aleph_message.models.execution.base import Payment, PaymentType
 from aleph_message.models.execution.environment import (
+    GpuDeviceClass,
     GpuProperties,
     HostRequirements,
     HypervisorType,
@@ -404,7 +405,7 @@ async def create(
                     GpuProperties(
                         vendor=selected_gpu.vendor,
                         device_name=selected_gpu.device_name,
-                        device_class=selected_gpu.device_class,
+                        device_class=GpuDeviceClass(selected_gpu.device_class),
                         device_id=selected_gpu.device_id,
                     )
                 ]

--- a/src/aleph_client/models.py
+++ b/src/aleph_client/models.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from typing import Optional
+from enum import Enum
+from typing import List, Optional
 
 from aleph_message.models import ItemHash
 from aleph_message.models.execution.environment import CpuProperties
@@ -45,12 +46,26 @@ class MachineProperties(BaseModel):
     cpu: CpuProperties
 
 
+class GpuDevice(BaseModel):
+    vendor: str
+    device_name: str
+    device_class: str
+    pci_host: str
+    device_id: str
+
+
+class GPUProperties(BaseModel):
+    devices: List[GpuDevice]
+    available_devices: List[GpuDevice]
+
+
 class MachineUsage(BaseModel):
     cpu: CpuUsage
     mem: MemoryUsage
     disk: DiskUsage
     period: UsagePeriod
     properties: MachineProperties
+    gpu: Optional[GPUProperties]
     active: bool = True
 
 
@@ -114,6 +129,7 @@ class CRNInfo(BaseModel):
     machine_usage: Optional[MachineUsage]
     qemu_support: Optional[bool]
     confidential_computing: Optional[bool]
+    gpu_support: Optional[bool]
 
     @property
     def display_cpu(self) -> str:
@@ -146,3 +162,4 @@ class CRNInfo(BaseModel):
             echo(f"Available Disk: {self.display_hdd}")
         echo(f"Support Qemu: {self.qemu_support}")
         echo(f"Support Confidential: {self.confidential_computing}")
+        echo(f"Support GPU: {self.gpu_support}")

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -56,6 +56,7 @@ def dummy_machine_info() -> MachineInfo:
                     vendor="AuthenticAMD",
                 ),
             ),
+            gpu=None,
         ),
         score=0.5,
         name="CRN",


### PR DESCRIPTION
Problem: If a user wants to select a GPU to assign it to a VM, he cannot do it.

Solution: Allow to get available GPUs from the CRN forcing the user to select it and allow assign it to a VM.

## How to test

Try to create an instance assigning a GPU. To be able to do it you will need to specify a CRN with GPUs available and a CRN hash, this can be solved attaching that arguments to the instance creation command: `--gpu --crn-url https://gpu-test-02.nergame.app/ --crn-hash 9ba6bd307ce7631b7e7cc5e2bed6285230ff405b1c8060d2a4318781d3552d71`