### PR TITLE
Fix unwanted uninit coco vm msg on instance list

### DIFF
--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -729,7 +729,7 @@ async def _show_instances(messages: List[InstanceMessage], node_list: NodeInfo):
     uninitialized_confidential_found = False
     for message in messages:
         info = scheduler_responses[message.item_hash]
-        if info["ipv6_logs"] == help_strings.VM_NOT_READY:
+        if info["confidential"] and info["ipv6_logs"] == help_strings.VM_NOT_READY:
             uninitialized_confidential_found = True
         name = Text(
             (


### PR DESCRIPTION
Jira: None

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.

## Changes

- Fix: `aleph instance list` was displaying "Boot uninitialized/unstarted confidential instances with..." not only on coco, but also for all unallocated instances