### PR TITLE
migrate test-docker to hatch

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Pytest in the Docker image
         run: |
-          docker run --entrypoint /opt/venv/bin/pytest aleph-client:${GITHUB_REF##*/} /opt/aleph-client/
+          docker run -w /opt/aleph-client --entrypoint /opt/venv/bin/hatch aleph-client:${GITHUB_REF##*/} run testing:test
 
       - name: MyPy in the Docker image
         run: |-
-          docker run --entrypoint /opt/venv/bin/mypy aleph-client:${GITHUB_REF##*/} --config-file /opt/aleph-client/mypy.ini /opt/aleph-client/src/ /opt/aleph-client/tests/
+          docker run -w /opt/aleph-client --entrypoint /opt/venv/bin/hatch aleph-client:${GITHUB_REF##*/} run linting:all

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN pip install --upgrade pip wheel twine
 # Preinstall dependencies for faster steps
 RUN pip install --upgrade secp256k1 coincurve aiohttp eciespy python-magic typer
 RUN pip install --upgrade 'aleph-message~=0.3.2' eth_account pynacl base58
-RUN pip install --upgrade pytest pytest-cov pytest-asyncio mypy types-setuptools pytest-asyncio fastapi httpx requests
+RUN pip install --upgrade hatch
 
 WORKDIR /opt/aleph-client/
 COPY . .


### PR DESCRIPTION
The test-docker testing job was still using raw commands instead of using hatch.