### PR TITLE
Fix: Could not import private key in base32/base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ or
 
 ### Formatting code
 
-> hatch run linting:format
+> hatch run linting:fmt
 
 ### Checking types
 

--- a/src/aleph_client/commands/help_strings.py
+++ b/src/aleph_client/commands/help_strings.py
@@ -71,3 +71,4 @@ TARGET_ADDRESS = "Target address. Defaults to current account address"
 AGGREGATE_SECURITY_KEY_PROTECTED = (
     "The aggregate key `security` is protected. Use `aleph aggregate [allow|revoke]` to manage it."
 )
+INVALID_KEY_FORMAT = "Invalid key format: {}"

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -67,6 +67,76 @@ def test_account_import_evm(env_files):
     assert new_key != old_key
 
 
+def test_account_import_evm_base32(env_files):
+    settings.CONFIG_FILE = env_files[1]
+    old_key = env_files[0].read_bytes()
+    result = runner.invoke(
+        app,
+        [
+            "account",
+            "create",
+            "--replace",
+            "--private-key-file",
+            str(env_files[0]),
+            "--chain",
+            "ETH",
+            "--private-key",
+            "JXINYIKE2QOUXCZRAFA2FG4AMYYPEOLS4OIGEZ2WK4WCQDWYSAMQ====",
+            "--key-format",
+            "base32",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    new_key = env_files[0].read_bytes()
+    assert new_key != old_key
+
+
+def test_account_import_evm_base64(env_files):
+    settings.CONFIG_FILE = env_files[1]
+    old_key = env_files[0].read_bytes()
+    result = runner.invoke(
+        app,
+        [
+            "account",
+            "create",
+            "--replace",
+            "--private-key-file",
+            str(env_files[0]),
+            "--chain",
+            "ETH",
+            "--private-key",
+            "TdDcIUTUHUuLMQFBopuAZjDyOXLjkGJnVlcsKA7YkBk=",
+            "--key-format",
+            "base64",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    new_key = env_files[0].read_bytes()
+    assert new_key != old_key
+
+
+def test_account_import_evm_format_invalid(env_files):
+    """Test that an invalid key format raises an error."""
+    settings.CONFIG_FILE = env_files[1]
+    result = runner.invoke(
+        app,
+        [
+            "account",
+            "create",
+            "--replace",
+            "--private-key-file",
+            str(env_files[0]),
+            "--chain",
+            "ETH",
+            "--private-key",
+            "TdDcIUTUHUuLMQFBopuAZjDyOXLjkGJnVlcsKA7YkBk=",
+            "--key-format",
+            "invalid",
+        ],
+    )
+    assert result.exit_code != 0, result.stdout
+
+
 def test_account_import_sol(env_files):
     settings.CONFIG_FILE = env_files[1]
     old_key = env_files[0].read_bytes()


### PR DESCRIPTION
The command `aleph account create` did not permit users to import their private key encoded in base32 or base64.

This adds the `--key-format` argument to the command to specify this.
