### PR TITLE
Fix: Hold Restrictions

### DIFF
--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -333,6 +333,16 @@ async def create(
             selector=True,
         ),
     )
+    if (tier.compute_units > 4 or confidential) and payment_type == PaymentType.hold:
+        console.print("VM with more than 4 Compute unit and/or confidential can't run using HOLD.", style="red")
+        if payment_chain in super_token_chains:
+            payment_type = PaymentType.superfluid
+            console.print("Switching payment type to PAY-As-You-Go (superfluid).", style="green")
+        else:
+            console.print("The current chain is not compatible with PAYG. Aborting instance creation.", style="red")
+            console.print(f"Compatible Chain : {super_token_chains}")
+            raise typer.Exit(code=1)
+
     name = name or validated_prompt("Instance name", lambda x: x and len(x) < 65)
     vcpus = tier.vcpus
     memory = tier.memory

--- a/src/aleph_client/commands/pricing.py
+++ b/src/aleph_client/commands/pricing.py
@@ -211,9 +211,13 @@ class Pricing:
                 if "vram" in tier:
                     row.append(f"{tier['vram'] / 1024:.0f}")
                 if "holding" in price_unit:
-                    row.append(
-                        f"{displayable_amount(Decimal(price_unit['holding']) * current_units, decimals=3)} tokens"
-                    )
+                    # If the pricing entity is confidential or compute units > 4, display "Not Available"
+                    if pricing_entity == PricingEntity.INSTANCE_CONFIDENTIAL or current_units > 4:
+                        row.append("Not Available")
+                    else:
+                        row.append(
+                            f"{displayable_amount(Decimal(price_unit['holding']) * current_units, decimals=3)} tokens"
+                        )
                 if "payg" in price_unit and pricing_entity in PAYG_GROUP:
                     payg_hourly = Decimal(price_unit["payg"]) * current_units
                     row.append(

--- a/src/aleph_client/commands/program.py
+++ b/src/aleph_client/commands/program.py
@@ -182,6 +182,14 @@ async def upload(
                 verbose=verbose,
             ),
         )
+        if (tier.compute_units > 4) and payment.type == PaymentType.hold:
+            console.print(
+                "Programs using more than 4 Compute Units require PAYG, which is not yet available. Please use HOLD "
+                "for programs with up to 4 Compute Units.",
+                style="red",
+            )
+            raise typer.Exit(code=1)
+
         name = name or validated_prompt("Program name", lambda x: x and len(x) < 65)
         vcpus = tier.vcpus
         memory = tier.memory

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -506,9 +506,11 @@ async def test_create_instance(args, expected, should_raise):
 
     if should_raise:
         with pytest.raises(typer.Exit) as exc_info:
-            await create_instance(args)
-        assert exc_info.value.exit_code == 1
+            returned = await create_instance(args)
+            mock_load_account.assert_called_once()
+            mock_validate_ssh_pubkey_file.return_value.read_text.assert_called_once()
 
+        assert exc_info.value.exit_code == 1
     else:
         returned = await create_instance(args)
         # Basic assertions for all cases


### PR DESCRIPTION
This PR adds a check to prevent users from creating a Hold (conf + > 4 compute units).
On the instance side, we attempt to fall back to a compatible chain when possible.
If fallback is not possible or program, we exit.

Related ClickUp, GitHub or Jira tickets : ALEPH-458

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.


## Changes

This pull request introduces several changes to the `aleph_client` project, focusing on handling payment types for instances and programs, and updating unit tests to reflect these changes. The most important changes include adding conditions for payment types based on compute units and confidentiality, and updating the unit tests to handle the new logic.

### Payment Type Handling:
* [`src/aleph_client/commands/instance/__init__.py`](diffhunk://#diff-fd31b02ee3ae2d7b6ac64e5cde06043cecefa0e398860fa03b1f68cfd8347668R336-R345): Added a condition to switch payment type to PAYG (superfluid) if the compute units exceed 4 or if the instance is confidential, and the payment type is HOLD. If the current chain is not compatible with PAYG, the instance creation is aborted.
* [`src/aleph_client/commands/program.py`](diffhunk://#diff-a7c9b415c7fb3b0e74b0d5b77aacedf352b673fdcfad5f41274b35c19087a6ffR185-R192): Added a condition to prevent programs using more than 4 compute units from using the HOLD payment type, as PAYG is required but not yet available.

### Pricing Display:
* [`src/aleph_client/commands/pricing.py`](diffhunk://#diff-a0654fbb32cd0459dee12adbe397983f2068b7bd7f9d0858790e76fe2e9bf9f9R214-R217): Updated the pricing display logic to show "Not Available" for confidential instances or instances with more than 4 compute units when the payment type is HOLD.

### Unit Tests:
* `tests/unit/test_instance.py`: 
  * Imported `typer` for handling exit codes in tests.
  * Modified the `create_mock_vm_coco_client` function to include a `should_raise` parameter to test the new payment type conditions. [[1]](diffhunk://#diff-c8e8940d2b8118ac89f73abb983596ea29016b835e719e14f8a8968e091904f3L383-R384) [[2]](diffhunk://#diff-c8e8940d2b8118ac89f73abb983596ea29016b835e719e14f8a8968e091904f3R396) [[3]](diffhunk://#diff-c8e8940d2b8118ac89f73abb983596ea29016b835e719e14f8a8968e091904f3R406) [[4]](diffhunk://#diff-c8e8940d2b8118ac89f73abb983596ea29016b835e719e14f8a8968e091904f3R415) [[5]](diffhunk://#diff-c8e8940d2b8118ac89f73abb983596ea29016b835e719e14f8a8968e091904f3L421-R426) [[6]](diffhunk://#diff-c8e8940d2b8118ac89f73abb983596ea29016b835e719e14f8a8968e091904f3L431-R437) [[7]](diffhunk://#diff-c8e8940d2b8118ac89f73abb983596ea29016b835e719e14f8a8968e091904f3R448) [[8]](diffhunk://#diff-c8e8940d2b8118ac89f73abb983596ea29016b835e719e14f8a8968e091904f3R459-R464)
  * Updated the `test_create_instance` function to handle the `should_raise` parameter and assert the correct exit code when the new conditions are met.
## How to test
Create `Instance / Program` with more than `4 compute unit` or/and `confidential` type.

## Print screen / video

![Hold_high_tier_reject](https://github.com/user-attachments/assets/dc1c371a-818a-4468-9e78-e6f07c356c9e)
![conf_and_switch](https://github.com/user-attachments/assets/08b39a20-bf09-49bd-b144-36952fc10ca0)
![ProgramReject](https://github.com/user-attachments/assets/be8667ae-fb74-40a4-85c5-899019fea195)

## Notes

It might be worth considering a refactor to move most of the logic to the SDK side. For example, in the price feature, 100% of the logic is currently in aleph-client, which could be painful for developers.


