### PR TITLE
fix(utils): Removed forced path for mksquashfs

### DIFF
--- a/src/aleph_client/utils.py
+++ b/src/aleph_client/utils.py
@@ -48,7 +48,7 @@ def create_archive(path: Path) -> tuple[Path, Encoding]:
         if settings.CODE_USES_SQUASHFS:
             logger.debug("Creating squashfs archive...")
             archive_path = Path(f"{path}.squashfs")
-            subprocess.check_call(["/usr/bin/mksquashfs", path, archive_path, "-noappend"])
+            subprocess.check_call(["mksquashfs", path, archive_path, "-noappend"])
             assert archive_path.is_file()
             return archive_path, Encoding.squashfs
         else:


### PR DESCRIPTION
Fixes an issue with `aleph program upload` on operating systems where `mksquashfs` is not installed at this location (eg on MacOS with homebrew it's at `/opt/homebrew/bin/mksquashfs`, and `/usr/bin` is not writable without disabling important security features of the OS).

Letting the OS figures out the location of the binary to use fixes this & works for everybody.

## Print screen / video

Before:
<img width="773" alt="image" src="https://github.com/user-attachments/assets/4f16cae5-0ad8-469d-bf79-d08217ecb40e" />

After:
<img width="919" alt="image" src="https://github.com/user-attachments/assets/a0df6fd1-5185-42e8-ae83-78533cb7f1d7" />
