### PR TITLE
Implement missing --json for `aleph instance list`

### DIFF
--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-import json
+import json as json_lib
 import logging
 import shutil
 from decimal import Decimal
@@ -864,7 +864,25 @@ async def list_instances(
             raise typer.Exit(code=1)
 
         execution = await client.instance.get_instance_executions_info(allocations)
-        await show_instances(messages=instances, allocations=allocations, executions=execution)
+
+        if not json:
+            await show_instances(messages=instances, allocations=allocations, executions=execution)
+        else:
+            # Create a single JSON array with one object per instance, combining all related data
+            instances_data = []
+            for message in instances:
+                allocation = allocations.root.get(message.item_hash, None)
+                execution_info = execution.root.get(message.item_hash, None)
+
+                instance_entry = {
+                    "instance": message.model_dump(),
+                    "allocation": allocation.model_dump() if allocation else None,
+                    "execution": execution_info.model_dump() if execution_info else None,
+                }
+                instances_data.append(instance_entry)
+
+            console = Console()
+            console.print(json_lib.dumps(instances_data, indent=2, default=str))
 
 
 @app.command()
@@ -956,7 +974,7 @@ async def logs(
     async with VmClient(account, domain) as manager:
         try:
             async for log in manager.get_logs(vm_id=vm_id):
-                log_data = json.loads(log)
+                log_data = json_lib.loads(log)
                 if "message" in log_data:
                     echo(log_data["message"])
         except aiohttp.ClientConnectorError as e:


### PR DESCRIPTION
This PR implements the missing `--json` parameter that is in the option but not actually taken into account.
It displays with indentation the raw data, which can then be used by the user / parsed by automation scripts etc.

We could consider filtering this data in the future to reduce the amount of data displayed, some of which is probably irrelevant, but kept it simple for now.

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [ ] All new code is covered by relevant tests.

## How to test

Simply run `aleph instance list --json` with an account that has instances (or pass `--address`, for example with ` 0x501DD421f2B9F96E3e20945f42aeCBDd4A607a03`

## Print screen / video

<img width="1728" height="1004" alt="image" src="https://github.com/user-attachments/assets/d3d423cf-7618-4609-b3c3-4879749271bc" />

