### PR TITLE
Feature: Handle `REMOVING` and `REMOVED` status

### DIFF
--- a/src/aleph_client/commands/message.py
+++ b/src/aleph_client/commands/message.py
@@ -60,8 +60,6 @@ async def get(
                 reason = await client.get_message_error(item_hash=ItemHash(item_hash))
                 typer.echo(colorful_json(json.dumps(reason, indent=4)))
             else:
-                if status == "removing":
-                    typer.echo(f"Removing reason : {message['reason']}")
                 typer.echo(colorful_json(json.dumps(message.model_dump(), indent=4, default=extended_json_encoder)))
 
 

--- a/src/aleph_client/commands/message.py
+++ b/src/aleph_client/commands/message.py
@@ -13,7 +13,11 @@ import typer
 from aleph.sdk import AlephHttpClient, AuthenticatedAlephHttpClient
 from aleph.sdk.account import _load_account
 from aleph.sdk.conf import settings
-from aleph.sdk.exceptions import ForgottenMessageError, MessageNotFoundError
+from aleph.sdk.exceptions import (
+    ForgottenMessageError,
+    MessageNotFoundError,
+    RemovedMessageError,
+)
 from aleph.sdk.query.filters import MessageFilter
 from aleph.sdk.query.responses import MessagesResponse
 from aleph.sdk.types import AccountFromPrivateKey, StorageEnum
@@ -48,9 +52,11 @@ async def get(
             typer.echo("Message does not exist on aleph.im")
         except ForgottenMessageError:
             typer.echo("Message has been forgotten on aleph.im")
+        except RemovedMessageError:
+            typer.echo("Message has been removed on aleph.im")
         if message:
             typer.echo(f"Message Status: {colorized_status(status)}")
-            if status == MessageStatus.REJECTED:
+            if status in [MessageStatus.REJECTED, MessageStatus.REMOVING]:
                 reason = await client.get_message_error(item_hash=ItemHash(item_hash))
                 typer.echo(colorful_json(json.dumps(reason, indent=4)))
             else:

--- a/src/aleph_client/commands/message.py
+++ b/src/aleph_client/commands/message.py
@@ -56,10 +56,12 @@ async def get(
             typer.echo("Message has been removed on aleph.im")
         if message:
             typer.echo(f"Message Status: {colorized_status(status)}")
-            if status in [MessageStatus.REJECTED, MessageStatus.REMOVING]:
+            if status == MessageStatus.REJECTED:
                 reason = await client.get_message_error(item_hash=ItemHash(item_hash))
                 typer.echo(colorful_json(json.dumps(reason, indent=4)))
             else:
+                if status == "removing":
+                    typer.echo(f"Removing reason : {message['reason']}")
                 typer.echo(colorful_json(json.dumps(message.model_dump(), indent=4, default=extended_json_encoder)))
 
 

--- a/src/aleph_client/commands/pricing.py
+++ b/src/aleph_client/commands/pricing.py
@@ -37,44 +37,6 @@ pricing_link = (
 )
 
 
-class PricingEntity(str, Enum):
-    STORAGE = "storage"
-    WEB3_HOSTING = "web3_hosting"
-    PROGRAM = "program"
-    PROGRAM_PERSISTENT = "program_persistent"
-    INSTANCE = "instance"
-    INSTANCE_CONFIDENTIAL = "instance_confidential"
-    INSTANCE_GPU_STANDARD = "instance_gpu_standard"
-    INSTANCE_GPU_PREMIUM = "instance_gpu_premium"
-
-
-class GroupEntity(str, Enum):
-    STORAGE = "storage"
-    WEBSITE = "website"
-    PROGRAM = "program"
-    INSTANCE = "instance"
-    CONFIDENTIAL = "confidential"
-    GPU = "gpu"
-    ALL = "all"
-
-
-PRICING_GROUPS: dict[str, list[PricingEntity]] = {
-    GroupEntity.STORAGE: [PricingEntity.STORAGE],
-    GroupEntity.WEBSITE: [PricingEntity.WEB3_HOSTING],
-    GroupEntity.PROGRAM: [PricingEntity.PROGRAM, PricingEntity.PROGRAM_PERSISTENT],
-    GroupEntity.INSTANCE: [PricingEntity.INSTANCE],
-    GroupEntity.CONFIDENTIAL: [PricingEntity.INSTANCE_CONFIDENTIAL],
-    GroupEntity.GPU: [PricingEntity.INSTANCE_GPU_STANDARD, PricingEntity.INSTANCE_GPU_PREMIUM],
-    GroupEntity.ALL: list(PricingEntity),
-}
-
-PAYG_GROUP: list[PricingEntity] = [
-    PricingEntity.INSTANCE,
-    PricingEntity.INSTANCE_CONFIDENTIAL,
-    PricingEntity.INSTANCE_GPU_STANDARD,
-    PricingEntity.INSTANCE_GPU_PREMIUM,
-]
-
 MAX_VALUE = Decimal(999_999_999)
 
 

--- a/src/aleph_client/commands/pricing.py
+++ b/src/aleph_client/commands/pricing.py
@@ -19,7 +19,6 @@ from aleph.sdk.client.services.pricing import (
 )
 from aleph.sdk.conf import settings
 from aleph.sdk.utils import displayable_amount
-from pydantic import BaseModel
 from rich import box
 from rich.console import Console, Group
 from rich.panel import Panel
@@ -28,32 +27,9 @@ from rich.text import Text
 
 from aleph_client.commands.instance.network import call_program_crn_list
 from aleph_client.commands.utils import colorful_json, setup_logging
-from aleph_client.utils import async_lru_cache, sanitize_url
+from aleph_client.utils import async_lru_cache
 
 logger = logging.getLogger(__name__)
-
-pricing_link = (
-    f"{sanitize_url(settings.API_HOST)}/api/v0/aggregates/0xFba561a84A537fCaa567bb7A2257e7142701ae2A.json?keys=pricing"
-)
-
-
-MAX_VALUE = Decimal(999_999_999)
-
-
-class SelectedTierPrice(BaseModel):
-    hold: Decimal
-    payg: Decimal  # Token by second
-    storage: Optional[SelectedTierPrice] = None
-
-
-class SelectedTier(BaseModel):
-    tier: int
-    compute_units: int
-    vcpus: int
-    memory: int
-    disk: int
-    gpu_model: Optional[str]
-    price: SelectedTierPrice
 
 
 class Pricing:

--- a/src/aleph_client/commands/pricing.py
+++ b/src/aleph_client/commands/pricing.py
@@ -37,6 +37,47 @@ pricing_link = (
 )
 
 
+class PricingEntity(str, Enum):
+    STORAGE = "storage"
+    WEB3_HOSTING = "web3_hosting"
+    PROGRAM = "program"
+    PROGRAM_PERSISTENT = "program_persistent"
+    INSTANCE = "instance"
+    INSTANCE_CONFIDENTIAL = "instance_confidential"
+    INSTANCE_GPU_STANDARD = "instance_gpu_standard"
+    INSTANCE_GPU_PREMIUM = "instance_gpu_premium"
+
+
+class GroupEntity(str, Enum):
+    STORAGE = "storage"
+    WEBSITE = "website"
+    PROGRAM = "program"
+    INSTANCE = "instance"
+    CONFIDENTIAL = "confidential"
+    GPU = "gpu"
+    ALL = "all"
+
+
+PRICING_GROUPS: dict[str, list[PricingEntity]] = {
+    GroupEntity.STORAGE: [PricingEntity.STORAGE],
+    GroupEntity.WEBSITE: [PricingEntity.WEB3_HOSTING],
+    GroupEntity.PROGRAM: [PricingEntity.PROGRAM, PricingEntity.PROGRAM_PERSISTENT],
+    GroupEntity.INSTANCE: [PricingEntity.INSTANCE],
+    GroupEntity.CONFIDENTIAL: [PricingEntity.INSTANCE_CONFIDENTIAL],
+    GroupEntity.GPU: [PricingEntity.INSTANCE_GPU_STANDARD, PricingEntity.INSTANCE_GPU_PREMIUM],
+    GroupEntity.ALL: list(PricingEntity),
+}
+
+PAYG_GROUP: list[PricingEntity] = [
+    PricingEntity.INSTANCE,
+    PricingEntity.INSTANCE_CONFIDENTIAL,
+    PricingEntity.INSTANCE_GPU_STANDARD,
+    PricingEntity.INSTANCE_GPU_PREMIUM,
+]
+
+MAX_VALUE = Decimal(999_999_999)
+
+
 class SelectedTierPrice(BaseModel):
     hold: Decimal
     payg: Decimal  # Token by second

--- a/src/aleph_client/commands/utils.py
+++ b/src/aleph_client/commands/utils.py
@@ -51,6 +51,8 @@ def colorized_status(status: MessageStatus) -> str:
         MessageStatus.PROCESSED: colors.GREEN,
         MessageStatus.PENDING: colors.YELLOW,
         MessageStatus.FORGOTTEN: colors.BRIGHT_BLACK,
+        MessageStatus.REMOVING: colors.YELLOW,
+        MessageStatus.REMOVED: colors.RED,
     }
     color = status_colors.get(status, colors.WHITE)
     return style(status, fg=color, bold=True)

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -391,14 +391,17 @@ def test_message_get(mocker, store_message_fixture):
     assert result.exit_code == 0
     assert FAKE_STORE_HASH_PUBLISHER in result.stdout
 
+
 def test_message_get_with_reject(mocker, store_message_fixture):
     message = StoreMessage.model_validate(store_message_fixture)
     mocker.patch("aleph.sdk.AlephHttpClient.get_message", return_value=[message, "rejected"])
-    mocker.patch("aleph.sdk.AlephHttpClient.get_message_error", return_value={'error_code': 100, 'details': {
-        "errors": [
-            "File not found: Could not retrieve file from storage at this time"
-        ]
-    }})
+    mocker.patch(
+        "aleph.sdk.AlephHttpClient.get_message_error",
+        return_value={
+            "error_code": 100,
+            "details": {"errors": ["File not found: Could not retrieve file from storage at this time"]},
+        },
+    )
     result = runner.invoke(
         app,
         [
@@ -408,14 +411,13 @@ def test_message_get_with_reject(mocker, store_message_fixture):
         ],
     )
     assert result.exit_code == 0
-    assert 'Message Status: rejected' in result.stdout
+    assert "Message Status: rejected" in result.stdout
+
 
 def test_message_get_with_removing(mocker, store_message_fixture):
     message = StoreMessage.model_validate(store_message_fixture)
     mocker.patch("aleph.sdk.AlephHttpClient.get_message", return_value=[message, "removing"])
-    mocker.patch("aleph.sdk.AlephHttpClient.get_message_error", return_value={
-        'reason': 'balance_insufficient'
-    })
+    mocker.patch("aleph.sdk.AlephHttpClient.get_message_error", return_value={"reason": "balance_insufficient"})
     result = runner.invoke(
         app,
         [
@@ -425,9 +427,8 @@ def test_message_get_with_removing(mocker, store_message_fixture):
         ],
     )
     assert result.exit_code == 0
-    assert 'Message Status: removing' in result.stdout
-    assert 'balance_insufficient' in result.stdout
-
+    assert "Message Status: removing" in result.stdout
+    assert "balance_insufficient" in result.stdout
 
 
 def test_message_find(mocker, store_message_fixture):

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -443,23 +443,6 @@ def test_message_get_with_forgotten(mocker):
     assert "Message has been forgotten on aleph.im" in result.stdout
 
 
-def test_message_get_with_removing(mocker, store_message_fixture):
-    message = StoreMessage.model_validate(store_message_fixture)
-    mocker.patch("aleph.sdk.AlephHttpClient.get_message", return_value=[message, "removing"])
-    mocker.patch("aleph.sdk.AlephHttpClient.get_message_error", return_value={"reason": "balance_insufficient"})
-    result = runner.invoke(
-        app,
-        [
-            "message",
-            "get",
-            FAKE_STORE_HASH,
-        ],
-    )
-    assert result.exit_code == 0
-    assert "Message Status: removing" in result.stdout
-    assert "balance_insufficient" in result.stdout
-
-
 def test_message_get_not_found(mocker):
     """Test the behavior when a message is not found."""
     # Mock the get_message method to raise MessageNotFoundError

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -7,6 +7,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from aleph.sdk.chains.ethereum import ETHAccount
 from aleph.sdk.conf import settings
+from aleph.sdk.exceptions import (
+    ForgottenMessageError,
+    MessageNotFoundError,
+    RemovedMessageError,
+)
 from aleph.sdk.query.responses import MessagesResponse
 from aleph.sdk.types import StorageEnum, StoredContent
 from aleph_message.models import PostMessage, StoreMessage
@@ -414,6 +419,30 @@ def test_message_get_with_reject(mocker, store_message_fixture):
     assert "Message Status: rejected" in result.stdout
 
 
+def test_message_get_with_forgotten(mocker):
+    """Test the behavior when a message has been forgotten."""
+    # Mock the get_message method to raise ForgottenMessageError
+    mocker.patch(
+        "aleph.sdk.AlephHttpClient.get_message",
+        side_effect=ForgottenMessageError(
+            f"The requested message {FAKE_STORE_HASH} has been forgotten by node1, node2"
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "message",
+            "get",
+            FAKE_STORE_HASH,
+        ],
+    )
+
+    # Verify output matches expected response for forgotten messages
+    assert result.exit_code == 0
+    assert "Message has been forgotten on aleph.im" in result.stdout
+
+
 def test_message_get_with_removing(mocker, store_message_fixture):
     message = StoreMessage.model_validate(store_message_fixture)
     mocker.patch("aleph.sdk.AlephHttpClient.get_message", return_value=[message, "removing"])
@@ -429,6 +458,49 @@ def test_message_get_with_removing(mocker, store_message_fixture):
     assert result.exit_code == 0
     assert "Message Status: removing" in result.stdout
     assert "balance_insufficient" in result.stdout
+
+
+def test_message_get_not_found(mocker):
+    """Test the behavior when a message is not found."""
+    # Mock the get_message method to raise MessageNotFoundError
+    mocker.patch(
+        "aleph.sdk.AlephHttpClient.get_message", side_effect=MessageNotFoundError(f"No such hash {FAKE_STORE_HASH}")
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "message",
+            "get",
+            FAKE_STORE_HASH,
+        ],
+    )
+
+    # Verify output matches expected response for not found messages
+    assert result.exit_code == 0
+    assert "Message does not exist on aleph.im" in result.stdout
+
+
+def test_message_get_removed(mocker):
+    """Test the behavior when a message has been removed."""
+    # Mock the get_message method to raise RemovedMessageError
+    mocker.patch(
+        "aleph.sdk.AlephHttpClient.get_message",
+        side_effect=RemovedMessageError(f"The requested message {FAKE_STORE_HASH} has been removed by admin"),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "message",
+            "get",
+            FAKE_STORE_HASH,
+        ],
+    )
+
+    # Verify output matches expected response for removed messages
+    assert result.exit_code == 0
+    assert "Message has been removed on aleph.im" in result.stdout
 
 
 def test_message_find(mocker, store_message_fixture):


### PR DESCRIPTION
This PR add the handling of the two new status `REMOVING` and `REMOVED`

Related ClickUp, GitHub or Jira tickets : ALEPH-573

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [] New classes and functions contain docstrings explaining what they provide.
- [] All new code is covered by relevant tests.
## Changes
This pull request adds support for handling messages that are in the process of being removed or have already been removed on aleph.im. It improves error handling and status reporting for these new message states.

**Error handling improvements:**

* Added `RemovedMessageError` to the list of exceptions handled in `message.py`, allowing the CLI to inform users when a message has been removed.
* Updated the `get` command to catch `RemovedMessageError` and display an appropriate message to the user.

**Status reporting enhancements:**

* Modified the logic for displaying message errors to include both `REJECTED` and `REMOVING` statuses, ensuring users see error details for messages being removed.
* Updated the `colorized_status` function to include color coding for the new `REMOVING` (yellow) and `REMOVED` (red) statuses, improving clarity in CLI output.

## Notes
On CLI the biggest impact of those status is on aleph instance list
since api2 is still using 0.7.4 (and scheduler using api2) some side effects is possible, PR is on draft waiting api2 to be upgraded for propper testing 
