### PR TITLE
Feature: script fake crn list for testing

### DIFF
--- a/scripts/api/crn_list/README.md
+++ b/scripts/api/crn_list/README.md
@@ -1,0 +1,41 @@
+maybe # CRN List API
+
+A simple FastAPI application that serves the CRN list from a local JSON file.
+
+## Setup
+
+1. Install the required dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the API server:
+
+```bash
+cd scripts/api/crn_list
+python crn_list.py
+```
+
+The server will start on port 8000 by default. You can specify a different port using the `PORT` environment variable:
+
+```bash
+PORT=8080 python crn_list.py
+```
+
+## Usage
+
+- The CRN list is available at: http://localhost:8000/crns.json
+- Documentation is available at: http://localhost:8000/docs
+
+## Configuring the Aleph Client SDK
+
+To make the Aleph client SDK use your local CRN list API instead of the production one, set the following environment variable:
+
+```bash
+export CRN_LIST_URL=http://localhost:8000/crns.json
+```
+
+## Modifying the CRN List
+
+To add or update test nodes in the CRN list, simply edit the `crn_list.json` file. The API will serve the updated content without requiring a restart.

--- a/scripts/api/crn_list/crn_list.json
+++ b/scripts/api/crn_list/crn_list.json
@@ -1,0 +1,85 @@
+{
+  "last_refresh": "2025-09-12T10:54:50.410762+00:00",
+  "crns": [
+    {
+      "hash": "388c36d26ed6c59e11c64c7bc858545fc50ea222106ed096d380c0e98da4bdc2",
+      "name": "OVH Staging",
+      "time": 1686824572.736,
+      "type": "compute",
+      "owner": "0x4145f182EF2F06b45E50468519C1B92C60FBd4A0",
+      "score": 0.981218669719485,
+      "banner": "",
+      "locked": false,
+      "parent": "",
+      "reward": "0x4145f182EF2F06b45E50468519C1B92C60FBd4A0",
+      "status": "linked",
+      "address": "http://ovh.staging.aleph.sh",
+      "manager": "",
+      "picture": "",
+      "authorized": "",
+      "description": "",
+      "performance": 0,
+      "multiaddress": "",
+      "score_updated": true,
+      "stream_reward": "0x4145f182EF2F06b45E50468519C1B92C60FBd4A0",
+      "inactive_since": null,
+      "decentralization": 0.952804599229347,
+      "registration_url": "",
+      "terms_and_conditions": "",
+      "config_from_crn": true,
+      "debug_config_from_crn_at": "2025-09-12T10:54:50.701148+00:00",
+      "debug_config_from_crn_error": "None",
+      "debug_usage_from_crn_at": "2025-09-12T10:54:50.701148+00:00",
+      "usage_from_crn_error": "None",
+      "version": "1.7.2",
+      "payment_receiver_address": "0xd95347956DebBAC208D51C3E005339A600894474",
+      "gpu_support": false,
+      "confidential_support": true,
+      "qemu_support": true,
+      "system_usage": {
+        "cpu": {
+          "count": 20,
+          "load_average": {
+            "load1": 0.078125,
+            "load5": 0.15380859375,
+            "load15": 0.20751953125
+          },
+          "core_frequencies": {
+            "min": 800,
+            "max": 4280
+          }
+        },
+        "mem": {
+          "total_kB": 67216409,
+          "available_kB": 67216409
+        },
+        "disk": {
+          "total_kB": 983016144,
+          "available_kB": 983016144
+        },
+        "period": {
+          "start_timestamp": "2025-09-12T10:55:00Z",
+          "duration_seconds": 60
+        },
+        "properties": {
+          "cpu": {
+            "architecture": "x86_64",
+            "vendor": "GenuineIntel",
+            "features": []
+          }
+        },
+        "gpu": {
+          "devices": [],
+          "available_devices": []
+        },
+        "active": true
+      },
+      "compatible_gpus": [],
+      "compatible_available_gpus": [],
+      "ipv6_check": {
+        "connection": true,
+        "connectivity": true
+      }
+    }
+  ]
+}

--- a/scripts/api/crn_list/crn_list.py
+++ b/scripts/api/crn_list/crn_list.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI(title="CRN List API")
+
+# Add CORS middleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Path to the CRN list JSON file
+CURRENT_DIR = Path(__file__).parent
+CRN_LIST_PATH = CURRENT_DIR / "crn_list.json"
+
+
+@app.get("/")
+async def root():
+    """Redirect to the CRNs endpoint."""
+    return {"message": "CRN List Mocked API - Use /crns.json endpoint to get the CRN list"}
+
+
+@app.get("/crns.json")
+async def get_crn_list():
+    """Return the CRN list from the JSON file."""
+    try:
+        with open(CRN_LIST_PATH) as f:
+            crn_data = json.load(f)
+            return crn_data
+    except Exception as e:
+        return {"error": f"Failed to load CRN list: {e!s}"}
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 8000))
+    uvicorn.run(app, host="localhost", port=port)

--- a/scripts/api/crn_list/requirements.txt
+++ b/scripts/api/crn_list/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.116.1
+uvicorn>=0.35.0


### PR DESCRIPTION
While testing we might need to use specific crn (exemple staging / local server) who is not in the crn list.

This Pr allow us to run a fake crn_list api locally.


## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [] All new code is covered by relevant tests.

## Documentation

not updated yet

## Changes
This pull request introduces a local mock CRN List API for development and testing, allowing the Aleph client SDK to use a locally served CRN list instead of the production endpoint. The changes add a FastAPI application, sample CRN list data, documentation, and update the Python dependencies to support this new API. Additionally, the Aleph SDK dependency is updated to a specific development branch.

**New Local CRN List API:**

* Added a FastAPI application (`crn_list.py`) that serves the CRN list from a local `crn_list.json` file, including CORS support and endpoints for the root and `/crns.json`.
* Created a sample `crn_list.json` file with a mocked CRN entry for local testing.
* Added a `requirements.txt` specifying `fastapi` and `uvicorn` as dependencies for running the API.
* Added a `README.md` with setup, usage instructions, and guidance on configuring the Aleph client SDK to use the local API.

**Dependency Updates:**

* Updated the `aleph-sdk-python` dependency in `pyproject.toml` to use a specific development branch from GitHub (`1yam-fake-crn-list`).

## How to test

export CRN_LIST_URL=http://localhost:8000/crns.json

python scripts/api/crn_list/crn_list.py

and then create instance


## Notes
Only ovh staging is in here for now, more can be added in the json if needed
