### PR TITLE
fix(instances): Remove deprecated advice to use aleph instance start

### DIFF
--- a/src/aleph_client/commands/instance/display.py
+++ b/src/aleph_client/commands/instance/display.py
@@ -519,8 +519,7 @@ class InstanceDisplay:
                         Text("Please make sure PAYG flow is running", style="orange3"),
                         Text.from_markup(
                             "\n[italic]↳[/italic] [orange3]Recommended action:[/orange3] \n"
-                            " ↳ aleph instance allocate [bright_cyan]<vm-item-hash>[/bright_cyan] \n"
-                            " ↳ aleph instance start [bright_cyan]<vm-item-hash>[/bright_cyan])"
+                            " ↳ aleph instance allocate [bright_cyan]<vm-item-hash>[/bright_cyan]"
                         ),
                     )
                     or Text(""),


### PR DESCRIPTION
Removes the advice to use `aleph instance start`, which doesn't exist. The `aleph instance allocate` command is enough to have instances up and running.

## Print screen / video

Current situation when a PAYG instance is not allocated
<img width="482" height="180" alt="image" src="https://github.com/user-attachments/assets/f6e93a8c-6223-4b15-afca-5aa12202e5ec" />

But the command doesn't exist
<img width="1356" height="414" alt="image" src="https://github.com/user-attachments/assets/1f5eaf81-87bb-4510-ae04-b2ca1191e0f6" />
