### PR TITLE
Fix: instance create crn is none when when giving --crn-hash or --crn…

### DIFF
--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -341,9 +341,7 @@ async def create(
         else (
             PricingEntity.INSTANCE_GPU_PREMIUM
             if gpu and premium
-            else PricingEntity.INSTANCE_GPU_STANDARD
-            if gpu
-            else PricingEntity.INSTANCE
+            else PricingEntity.INSTANCE_GPU_STANDARD if gpu else PricingEntity.INSTANCE
         )
     )
 


### PR DESCRIPTION
In aleph instance create:
https://github.com/aleph-im/aleph-client/blob/f61e49760db114062568c4c118de2b89f5eeaabe/src/aleph_client/commands/instance/__init__.py#L542
This comparaison is wrong since `crn` is only used when finding a specific crn on the crn list:
and crn_info is set
https://github.com/aleph-im/aleph-client/blob/f61e49760db114062568c4c118de2b89f5eeaabe/src/aleph_client/commands/instance/__init__.py#L500

So we should only ensure crn_info is set but not crn, since if we select a crn using the UI crn_url and crn_hash is None and crn is then None


## Changes

This pull request makes small adjustments to the logic for determining pricing entities and requirements when creating an instance in `src/aleph_client/commands/instance/__init__.py`. The changes simplify conditional checks and improve code clarity.

*Pricing entity selection:*

* The conditional logic for selecting the correct `PricingEntity` based on GPU and premium options has been refactored for improved readability.

*Requirements initialization:*

* The check for initializing requirements and related variables now only depends on `crn_info` instead of both `crn` and `crn_info`, streamlining the condition.
## How to test

create a payg or credit or confidential instance 
