### PR TITLE
Fix Holding Tier restrictions

### DIFF
--- a/src/aleph_client/commands/instance/__init__.py
+++ b/src/aleph_client/commands/instance/__init__.py
@@ -373,7 +373,7 @@ async def create(
 
         # Options shown to the user
         if pricing_entity == PricingEntity.INSTANCE and payment_type == PaymentType.hold:
-            options = ["1", "2", "3", "4"]  # hold instances up to tier 4
+            options = ["1", "2", "3"]  # hold instances up to tier 3 (4 compute units)
             pool = eligible or tiers
         else:
             pool = eligible or tiers


### PR DESCRIPTION
Fix: Removed tier 4 from the allowed tier list for holding.

## Self proofreading checklist

- [X] The new code clear, easy to read and well commented.
- [X] New code does not duplicate the functions of builtin or popular libraries.
- [X] An LLM was used to review the new code and look for simplifications.
- [X] New classes and functions contain docstrings explaining what they provide.
- [X] All new code is covered by relevant tests.

## Changes

Removed tier 4 from that allowed tier list for holding tier

## How to test

Try to create a big tier VM (more than 4 compute units) and the CLI will not allow it.
