### PR TITLE
Fix: use WindowsSelectorEventLoopPolicy instead of ProactorEventLoop …

### DIFF
--- a/src/aleph_client/utils.py
+++ b/src/aleph_client/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 import os
@@ -16,7 +17,6 @@ from typing import Optional, Union
 from urllib.parse import ParseResult, urlparse
 from zipfile import BadZipFile, ZipFile
 
-import asyncio
 import aiohttp
 import hid
 import typer
@@ -101,6 +101,7 @@ class AsyncTyper(typer.Typer):
                 # This is needed because aiodns requires SelectorEventLoop
                 if sys.platform == "win32":
                     from asyncio import windows_events
+
                     asyncio.set_event_loop_policy(windows_events.WindowsSelectorEventLoopPolicy())
                 return asyncio.run(f(*args, **kwargs))
 


### PR DESCRIPTION
…for windows

User had issue using CLI on windows due to aiodns.

https://github.com/aio-libs/aiodns/issues/86

Related ClickUp, GitHub or Jira tickets : ALEPH-694

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.

## Changes
This pull request addresses compatibility issues with asynchronous execution on Windows systems by ensuring the correct event loop policy is used when running async functions. The main change is focused on improving Windows support for libraries that require a specific event loop.

**Windows compatibility improvements:**

* Updated the `maybe_run_async` utility function in `src/aleph_client/utils.py` to set the event loop policy to `WindowsSelectorEventLoopPolicy` on Windows systems. This ensures compatibility with libraries like `aiodns` that require the `SelectorEventLoop` instead of the default `ProactorEventLoop` on Windows.

## How to test
Creating instance using windows

## Print screen / video

<img width="2510" height="1358" alt="image" src="https://github.com/user-attachments/assets/cd0c276d-5d0b-4a27-a409-a9f959f84012" />



