### PR TITLE
Fix: Program Upload commands

### DIFF
--- a/src/aleph_client/commands/program.py
+++ b/src/aleph_client/commands/program.py
@@ -148,7 +148,7 @@ async def upload(
     payment = Payment(
         chain=payment_chain,
         receiver=None,
-        type=None,  # Payment Type should be None for program
+        type=PaymentType.hold,
     )
 
     async with AuthenticatedAlephHttpClient(account=account, api_server=settings.API_HOST) as client:


### PR DESCRIPTION
aleph program upload fastapi.zip main:app --runtime bd79839bf96e595a06da5ac0b6ba51dea6f7e2591bb913deccded04d831d29f4 --vcpus 1 --memory 128 --internet --persistent-volume comment=Persistance,mount=/var/lib/example,name=increment-storage,size_mib=1

https://api.aleph.im/api/v0/messages/c27e53ec26f3a6384539cfa7adc4bf0d7589bc8cec86603e4f06ed18c5d1dbc1

We should allow the overload of tier using --vcpus or --memory

Related ClickUp, GitHub or Jira tickets : ALEPH-XXX

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.

## Changes

This pull request updates the `upload` command in `src/aleph_client/commands/program.py` to improve how program payments and resource specifications are handled. The main changes clarify payment type handling for programs and allow for more flexible resource specification during program uploads.

Payment handling changes:

* The `Payment` object now sets `type=None` rather than `PaymentType.hold` for program uploads, ensuring that payment type is correctly unset for this use case.

Resource specification improvements:

* The values for `vcpus` and `memory` are now conditionally assigned: if user-provided values are present, they are used; otherwise, default values from `specs` are applied, allowing users to override resource specifications during program upload.

## How to test

Explain how to test your PR.
If a specific config is required explain it here (account, data entry, ...)

## Print screen / video

Upload here screenshots or videos showing the changes if relevant.

## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in another repo, or merges into another PR (i.o. main), it should also be mentioned here
