### PR TITLE
Fix: better UX went switch key using aleph account config

### DIFF
--- a/src/aleph_client/commands/account.py
+++ b/src/aleph_client/commands/account.py
@@ -637,7 +637,8 @@ async def configure(
 
             console.print("[bold cyan]Available unlinked private keys:[/bold cyan]")
             for idx, key in enumerate(unlinked_keys, start=1):
-                console.print(f"[{idx}] {key}")
+                acc = _load_account(private_key_str=None, private_key_path=key, chain=chain)
+                console.print(f"[{idx}] {key} - {acc.get_address()}")
 
             key_choice = Prompt.ask("Choose a private key by index")
             if key_choice.isdigit():


### PR DESCRIPTION
When doing `aleph account config`  and switching key, we only display path of the key, it's may be hard for user to know which address they choosing

Related ClickUp, GitHub or Jira tickets : None

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.

## Changes
This pull request improves the user experience when configuring accounts by displaying the address associated with each available unlinked private key, making it easier to identify which key to select.

* User experience improvement:
  * In `src/aleph_client/commands/account.py`, the list of unlinked private keys now shows both the key and its corresponding address, helping users make more informed selections.
## How to test

`aleph account config`

## Print screen / video

BEFORE
<img width="1722" height="364" alt="image" src="https://github.com/user-attachments/assets/3df15bec-b594-48bc-b450-66d903e91a84" />

AFTER
<img width="1605" height="442" alt="image" src="https://github.com/user-attachments/assets/6c2d2275-616d-477e-b9f7-b0f920ee8f8f" />

Upload here screenshots or videos showing the changes if relevant.

