### PR TITLE
fix(cli): fall back when file list endpoint returns 404

### DIFF
--- a/src/aleph_client/commands/files.py
+++ b/src/aleph_client/commands/files.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json as json_lib
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from hashlib import sha256
 from pathlib import Path
@@ -21,6 +21,7 @@ from rich import box
 from aleph.sdk import AlephHttpClient, AuthenticatedAlephHttpClient
 from aleph.sdk.conf import settings
 from aleph.sdk.exceptions import InsufficientFundsError
+from aleph.sdk.query.filters import MessageFilter
 from aleph.sdk.types import StorageEnum, StoredContent, TokenType
 from aleph.sdk.utils import safe_getattr
 from aleph_client.commands import help_strings
@@ -298,6 +299,49 @@ class GetAccountFilesQueryParams(BaseModel):
     )
 
 
+def _normalize_files_data_from_messages(address: str, messages_data) -> dict:
+    files = []
+    total_size = 0
+
+    for message in messages_data.messages:
+        content = getattr(message, "content", None)
+        if not content:
+            continue
+
+        file_hash = getattr(content, "item_hash", None)
+        message_hash = getattr(message, "item_hash", None)
+        if not file_hash or not message_hash:
+            continue
+
+        size = getattr(content, "size", None) or 0
+        try:
+            size_int = int(size)
+        except (TypeError, ValueError):
+            size_int = 0
+
+        total_size += size_int
+        created = datetime.fromtimestamp(message.time, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f%z")
+
+        files.append(
+            {
+                "file_hash": str(file_hash),
+                "size": str(size_int),
+                "type": str(getattr(content, "item_type", "file")),
+                "created": created,
+                "item_hash": str(message_hash),
+            }
+        )
+
+    return {
+        "files": files,
+        "pagination_page": messages_data.pagination_page,
+        "pagination_total": messages_data.pagination_total,
+        "pagination_per_page": messages_data.pagination_per_page,
+        "address": address,
+        "total_size": str(total_size),
+    }
+
+
 def _show_files(files_data: dict) -> None:
     table = get_table(title="Files Information", box=box.SIMPLE_HEAVY)
     table.add_column("File Hash", style="cyan", no_wrap=True, min_width=None)
@@ -373,16 +417,31 @@ async def list_files(
         query_params = GetAccountFilesQueryParams(pagination=pagination, page=page, sort_order=sort_order)
 
         uri = f"{settings.API_HOST}/api/v0/addresses/{address}/files"
+        files_data = None
         async with aiohttp.ClientSession() as session:
             response = await session.get(uri, params=query_params.model_dump())
             if response.status == 200:
                 files_data = await response.json()
-                formatted_files_data = json_lib.dumps(files_data, indent=4)
-                if not json:
-                    _show_files(files_data)
-                else:
-                    typer.echo(formatted_files_data)
-            else:
+            elif response.status != 404:
                 typer.echo(f"Failed to retrieve files for address {address}. Status code: {response.status}")
+                return
+
+        if files_data is None:
+            async with AlephHttpClient(api_server=settings.API_HOST) as client:
+                messages_data = await client.get_messages(
+                    page_size=pagination,
+                    page=page,
+                    message_filter=MessageFilter(
+                        message_types=[MessageType.store],
+                        addresses=[address],
+                    ),
+                )
+            files_data = _normalize_files_data_from_messages(address=address, messages_data=messages_data)
+
+        formatted_files_data = json_lib.dumps(files_data, indent=4)
+        if not json:
+            _show_files(files_data)
+        else:
+            typer.echo(formatted_files_data)
     else:
         typer.echo("Error: Please provide either a private key, private key file, or an address.")

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from tempfile import NamedTemporaryFile
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -956,7 +957,7 @@ def test_file_list(mock_aiohttp_client_session):
     assert "0dd9bb810b7a31cc50c8ad1e6569905" in result.stdout
 
 
-def test_file_list_error(mocker):
+def test_file_list_error():
     """Test error handling in the file list command when API returns an error."""
     # Create a mock response with error status
     mock_response = AsyncMock()
@@ -967,7 +968,58 @@ def test_file_list_error(mocker):
     mock_session.__aenter__.return_value = mock_session
     mock_session.get.return_value = mock_response
 
-    # Patch aiohttp.ClientSession to return our mock
+    mock_messages = SimpleNamespace(
+        pagination_page=1,
+        pagination_total=1,
+        pagination_per_page=100,
+        messages=[
+            SimpleNamespace(
+                time=1738837907,
+                item_hash=FAKE_STORE_HASH,
+                content=SimpleNamespace(
+                    item_hash="QmXSEnpQCnUfeGFoSjY1XAK1Cuad5CtAaqyachGTtsFSuA",
+                    item_type="ipfs",
+                    size=1024,
+                ),
+            )
+        ],
+    )
+
+    with (
+        patch("aiohttp.ClientSession", return_value=mock_session),
+        patch("aleph_client.commands.files.AlephHttpClient", autospec=True) as mock_client_class,
+    ):
+        mock_client = mock_client_class.return_value
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.get_messages = AsyncMock(return_value=mock_messages)
+
+        result = runner.invoke(
+            app,
+            [
+                "file",
+                "list",
+                "--address",
+                "0xe0aaF578B287de16852dbc54Ae34a263FF2F4b9E",
+            ],
+        )
+
+    # The command should fall back to STORE messages when the legacy files endpoint is unavailable.
+    assert result.exit_code == 0
+    assert "Address:" in result.stdout
+    assert "Total Item: 1" in result.stdout
+    assert "Failed to retrieve files for address" not in result.stdout
+
+
+def test_file_list_non_404_error():
+    """Test that non-404 errors are still surfaced directly."""
+    mock_response = AsyncMock()
+    mock_response.status = 500
+
+    mock_session = AsyncMock()
+    mock_session.__aenter__.return_value = mock_session
+    mock_session.get.return_value = mock_response
+
     with patch("aiohttp.ClientSession", return_value=mock_session):
         result = runner.invoke(
             app,
@@ -979,7 +1031,6 @@ def test_file_list_error(mocker):
             ],
         )
 
-    # The command should run without crashing but report the error
     assert result.exit_code == 0
     assert "Failed to retrieve files for address" in result.stdout
-    assert "Status code: 404" in result.stdout
+    assert "Status code: 500" in result.stdout


### PR DESCRIPTION
## Summary
Add a fallback for `aleph file list` when `/api/v0/addresses/{address}/files` returns 404.

## Changes
- try the legacy files endpoint first
- fall back to querying STORE messages via `messages.json`
- keep non-404 errors surfaced directly
- add focused tests for the fallback path

## Context
This started failing for us around April 26, 2026 at 1:00 PM, while balance and messages endpoints still returned 200.