### PR TITLE
fix(files): preserve directory tree on `file upload`

### DIFF
--- a/src/aleph_client/commands/files.py
+++ b/src/aleph_client/commands/files.py
@@ -250,7 +250,7 @@ async def upload(
             cid = await upload_directory(path)
             if not cid:
                 typer.echo("CID not found in response.")
-                typer.Exit(code=1)
+                raise typer.Exit(code=1)
             await pin(cid, channel, private_key, private_key_file, chain, ref, address, metadata, debug)
         else:
             typer.echo(f"Error: File not found: '{path}'")

--- a/src/aleph_client/commands/files.py
+++ b/src/aleph_client/commands/files.py
@@ -195,30 +195,51 @@ async def upload(
             typer.echo(f"Upload directory {path}...")
 
             async def upload_directory(directory: Path):
+                # Kubo's /api/v0/add expects each entry as a multipart part named "file";
+                # the filename (with slashes) encodes the relative path, so the directory
+                # tree must be flattened into individual parts rather than a dict of paths.
                 params = {"recursive": "true", "wrap-with-directory": "true"}
+                form = aiohttp.FormData()
+                file_handles: list = []
 
-                files = {}
-                for _path in directory.rglob("*"):
-                    if _path.is_file():
-                        relative_path = _path.relative_to(directory)
-                        files[str(relative_path)] = open(_path, "rb")
+                for _path in sorted(directory.rglob("*")):
+                    relative_path = _path.relative_to(directory)
+                    if _path.is_dir():
+                        form.add_field(
+                            "file",
+                            b"",
+                            filename=str(relative_path),
+                            content_type="application/x-directory",
+                        )
+                    elif _path.is_file():
+                        fh = open(_path, "rb")
+                        file_handles.append(fh)
+                        form.add_field(
+                            "file",
+                            fh,
+                            filename=str(relative_path),
+                            content_type="application/octet-stream",
+                        )
 
                 url = urlparse(settings.IPFS_GATEWAY)._replace(path="/api/v0/add").geturl()
-                async with aiohttp.ClientSession() as session:
-                    response = await session.post(url, params=params, data=files)
-                    response.raise_for_status()
+                try:
+                    async with aiohttp.ClientSession() as session:
+                        response = await session.post(url, params=params, data=form)
+                        response.raise_for_status()
 
-                    # Parse the response line-by-line
-                    cid_v0 = None
-                    data = await response.text()
-                    for line in data.strip().splitlines():
-                        entry = json_lib.loads(line)
-                        cid_v0 = entry.get("Hash")
+                        cid_v0 = None
+                        data = await response.text()
+                        for line in data.strip().splitlines():
+                            entry = json_lib.loads(line)
+                            cid_v0 = entry.get("Hash")
 
-                    if not cid_v0:
-                        return None
+                        if not cid_v0:
+                            return None
 
-                    return cid_v0
+                        return cid_v0
+                finally:
+                    for fh in file_handles:
+                        fh.close()
 
             total_size = 0
             for fp in path.rglob("*"):


### PR DESCRIPTION
  Directory uploads sent each file as a dict entry, which aiohttp encoded
  with the relative path as the multipart field name. Kubo's /api/v0/add
  requires every part named "file" with the path in the filename, so
  subdirectories and nested files were dropped.

  Build the multipart with aiohttp.FormData: name every part "file", put
  the relative path in the filename, emit application/x-directory parts for
  directories, and close file handles after upload.