### PR TITLE
docs: archive repository in favor of the Rust CLI (aleph-rs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # aleph-client
 
+> [!WARNING]
+> **This repository is archived and no longer maintained.**
+>
+> `aleph-client` has been superseded by the new Rust-based CLI, which is the actively developed and supported command-line interface for Aleph Cloud going forward. Please migrate to it:
+>
+> 👉 **[aleph-im/aleph-rs](https://github.com/aleph-im/aleph-rs)**
+>
+> This repository remains available for reference only. No further releases, bug fixes, or feature work will happen here.
+
 The official command-line interface (CLI) for [Aleph Cloud](https://www.aleph.cloud) — a decentralized cloud computing platform.
 
 ## What is Aleph Cloud?


### PR DESCRIPTION
## Summary

This repository (`aleph-client`, the Python CLI) is now **archived** and superseded by the new Rust-based CLI, which is the actively developed and supported command-line interface for Aleph Cloud going forward.

This PR adds a prominent archival notice to the top of the `README.md` directing users to migrate to:

👉 **[aleph-im/aleph-rs](https://github.com/aleph-im/aleph-rs)**

## What changed

- Added a `> [!WARNING]` callout at the top of the README stating the repo is archived/unmaintained and pointing to the Rust CLI.
- Clarified that no further releases, bug fixes, or feature work will happen here.

## Follow-up

After this merges, the GitHub repository itself should be set to **Archived** in repo settings (Settings → General → Danger Zone → Archive this repository).

🤖 Generated with [Claude Code](https://claude.com/claude-code)